### PR TITLE
fix: release - run yarn install with node@14

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -49,6 +49,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - run: yarn install
+        with:
+          node-version: '14'
       - name: Make release
         id: release
         env:


### PR DESCRIPTION
see #293 
yarn install is now working, using node@14 :)
https://github.com/GeoffreyHervet/graphql-request/runs/3904514656?check_suite_focus=true

