### PR TITLE
improve(generator): export SDDM term aligning with input

### DIFF
--- a/src/extensions/SchemaErrors/injectTypenameOnRootResultFields.test.ts
+++ b/src/extensions/SchemaErrors/injectTypenameOnRootResultFields.test.ts
@@ -43,7 +43,7 @@ test.each<CasesQuery>([
   )
   injectTypenameOnRootResultFields({
     request: graffleMappedResultToRequest(docWithout),
-    sddm: GraffleSchemaErrors.schemaDrivenDataMap,
+    sddm: GraffleSchemaErrors.schemaMap,
   })
   expect(docWithout.document).toMatchObject(docWith.document)
 })

--- a/src/extensions/SchemaErrors/tests/fixture/graffle/_.ts
+++ b/src/extensions/SchemaErrors/tests/fixture/graffle/_.ts
@@ -5,6 +5,6 @@
 import './modules/global.js'
 
 export { create } from './modules/client.js'
-export { schemaDrivenDataMap } from './modules/schema-driven-data-map.js'
+export { schemaDrivenDataMap as schemaMap } from './modules/schema-driven-data-map.js'
 export { Select } from './modules/select.js'
 export * as SelectionSets from './modules/selection-sets.js'

--- a/src/extensions/SchemaErrors/tests/fixture/graffle/__.ts
+++ b/src/extensions/SchemaErrors/tests/fixture/graffle/__.ts
@@ -1,1 +1,2 @@
 export * as GraffleSchemaErrors from './_.js'
+export { schemaDrivenDataMap as schemaMap } from './modules/schema-driven-data-map.js'

--- a/src/generator/generator/__snapshots__/generate.test.ts.snap
+++ b/src/generator/generator/__snapshots__/generate.test.ts.snap
@@ -68,7 +68,7 @@ exports[`kitchen-sink generated modules > _.ts 1`] = `
 import './modules/global.js'
 
 export { create } from './modules/client.js'
-export { schemaDrivenDataMap } from './modules/schema-driven-data-map.js'
+export { schemaDrivenDataMap as schemaMap } from './modules/schema-driven-data-map.js'
 export { Select } from './modules/select.js'
 export * as SelectionSets from './modules/selection-sets.js'
 "
@@ -76,6 +76,7 @@ export * as SelectionSets from './modules/selection-sets.js'
 
 exports[`kitchen-sink generated modules > __.ts 1`] = `
 "export * as Graffle from './_.js'
+export { schemaDrivenDataMap as schemaMap } from './modules/schema-driven-data-map.js'
 "
 `;
 

--- a/src/generator/generators/_.ts
+++ b/src/generator/generators/_.ts
@@ -20,7 +20,9 @@ export const ModuleGenerator_ = createModuleGenerator(
       `export { Select } from './modules/${getImportName(config, ModuleGeneratorSelect)}'`,
       `export { create } from './modules/${getImportName(config, ModuleGeneratorClient)}'`,
       `export * as SelectionSets from './modules/${getImportName(config, ModuleGeneratorSelectionSets)}'`,
-      `export { schemaDrivenDataMap } from './modules/${getImportName(config, ModuleGeneratorSchemaDrivenDataMap)}'`,
+      `export { schemaDrivenDataMap as schemaMap } from './modules/${
+        getImportName(config, ModuleGeneratorSchemaDrivenDataMap)
+      }'`,
     )
 
     return code

--- a/src/generator/generators/__.ts
+++ b/src/generator/generators/__.ts
@@ -2,6 +2,7 @@ import { capitalizeFirstLetter } from '../../lib/prelude.js'
 import { defaultName } from '../config/defaults.js'
 import { createModuleGenerator, getImportName } from '../helpers/moduleGenerator.js'
 import { ModuleGenerator_ } from './_.js'
+import { ModuleGeneratorSchemaDrivenDataMap } from './SchemaDrivenDataMap.js'
 
 // todo remove, use config.name simply, any processing, do in config constructor
 export const defaultNamespace = `Graffle`
@@ -12,6 +13,9 @@ export const ModuleGenerator__ = createModuleGenerator(
     const namespace = config.name === defaultName ? defaultNamespace : capitalizeFirstLetter(config.name)
     code(
       `export * as ${namespace} from './${getImportName(config, ModuleGenerator_)}'`,
+      `export { schemaDrivenDataMap as schemaMap } from './modules/${
+        getImportName(config, ModuleGeneratorSchemaDrivenDataMap)
+      }'`,
     )
     return code
   },

--- a/tests/_/schemas/kitchen-sink/graffle/_.ts
+++ b/tests/_/schemas/kitchen-sink/graffle/_.ts
@@ -5,6 +5,6 @@
 import './modules/global.js'
 
 export { create } from './modules/client.js'
-export { schemaDrivenDataMap } from './modules/schema-driven-data-map.js'
+export { schemaDrivenDataMap as schemaMap } from './modules/schema-driven-data-map.js'
 export { Select } from './modules/select.js'
 export * as SelectionSets from './modules/selection-sets.js'

--- a/tests/_/schemas/kitchen-sink/graffle/__.ts
+++ b/tests/_/schemas/kitchen-sink/graffle/__.ts
@@ -1,1 +1,2 @@
 export * as Graffle from './_.js'
+export { schemaDrivenDataMap as schemaMap } from './modules/schema-driven-data-map.js'

--- a/tests/_/schemas/mutation-only/graffle/_.ts
+++ b/tests/_/schemas/mutation-only/graffle/_.ts
@@ -5,6 +5,6 @@
 import './modules/global.js'
 
 export { create } from './modules/client.js'
-export { schemaDrivenDataMap } from './modules/schema-driven-data-map.js'
+export { schemaDrivenDataMap as schemaMap } from './modules/schema-driven-data-map.js'
 export { Select } from './modules/select.js'
 export * as SelectionSets from './modules/selection-sets.js'

--- a/tests/_/schemas/mutation-only/graffle/__.ts
+++ b/tests/_/schemas/mutation-only/graffle/__.ts
@@ -1,1 +1,2 @@
 export * as MutationOnly from './_.js'
+export { schemaDrivenDataMap as schemaMap } from './modules/schema-driven-data-map.js'

--- a/tests/_/schemas/pokemon/graffle/_.ts
+++ b/tests/_/schemas/pokemon/graffle/_.ts
@@ -5,6 +5,6 @@
 import './modules/global.js'
 
 export { create } from './modules/client.js'
-export { schemaDrivenDataMap } from './modules/schema-driven-data-map.js'
+export { schemaDrivenDataMap as schemaMap } from './modules/schema-driven-data-map.js'
 export { Select } from './modules/select.js'
 export * as SelectionSets from './modules/selection-sets.js'

--- a/tests/_/schemas/pokemon/graffle/__.ts
+++ b/tests/_/schemas/pokemon/graffle/__.ts
@@ -1,1 +1,2 @@
 export * as Pokemon from './_.js'
+export { schemaDrivenDataMap as schemaMap } from './modules/schema-driven-data-map.js'

--- a/tests/_/schemas/query-only/graffle/_.ts
+++ b/tests/_/schemas/query-only/graffle/_.ts
@@ -5,6 +5,6 @@
 import './modules/global.js'
 
 export { create } from './modules/client.js'
-export { schemaDrivenDataMap } from './modules/schema-driven-data-map.js'
+export { schemaDrivenDataMap as schemaMap } from './modules/schema-driven-data-map.js'
 export { Select } from './modules/select.js'
 export * as SelectionSets from './modules/selection-sets.js'

--- a/tests/_/schemas/query-only/graffle/__.ts
+++ b/tests/_/schemas/query-only/graffle/__.ts
@@ -1,1 +1,2 @@
 export * as QueryOnly from './_.js'
+export { schemaDrivenDataMap as schemaMap } from './modules/schema-driven-data-map.js'

--- a/website/content/guides/50_appendix/05_custom-scalars.md
+++ b/website/content/guides/50_appendix/05_custom-scalars.md
@@ -22,7 +22,7 @@ pnpm graffle generate --schema ...
 Then you augment your Graffle instance with the SDDM, and finally register your scalars:
 
 ```ts
-import { schemaDrivenDataMap as schemaMap } from './graffle/__.js'
+import { schemaMap } from './graffle/__.js'
 
 const graffle = Graffle
   .create({

--- a/website/graffle/_.ts
+++ b/website/graffle/_.ts
@@ -5,6 +5,6 @@
 import "./modules/global.js";
 
 export { create } from "./modules/client.js";
-export { schemaDrivenDataMap } from "./modules/schema-driven-data-map.js";
+export { schemaDrivenDataMap as schemaMap } from "./modules/schema-driven-data-map.js";
 export { Select } from "./modules/select.js";
 export * as SelectionSets from "./modules/selection-sets.js";

--- a/website/graffle/__.ts
+++ b/website/graffle/__.ts
@@ -1,1 +1,2 @@
 export * as Graffle from "./_.js";
+export { schemaDrivenDataMap as schemaMap } from "./modules/schema-driven-data-map.js";

--- a/website/pokemon/_.ts
+++ b/website/pokemon/_.ts
@@ -5,6 +5,6 @@
 import "./modules/global.js";
 
 export { create } from "./modules/client.js";
-export { schemaDrivenDataMap } from "./modules/schema-driven-data-map.js";
+export { schemaDrivenDataMap as schemaMap } from "./modules/schema-driven-data-map.js";
 export { Select } from "./modules/select.js";
 export * as SelectionSets from "./modules/selection-sets.js";

--- a/website/pokemon/__.ts
+++ b/website/pokemon/__.ts
@@ -1,1 +1,2 @@
 export * as Pokemon from "./_.js";
+export { schemaDrivenDataMap as schemaMap } from "./modules/schema-driven-data-map.js";


### PR DESCRIPTION
This PR creates consistency between what the generator code exports and the Graffle constructor input. It allows for field punning for one thing, and also reduces terms as seen the code. We still use the more verbose term in our docs and internal code, at least for now.