### PR TITLE
feat(extension): support inline type extensions

### DIFF
--- a/src/entrypoints/extensionkit.ts
+++ b/src/entrypoints/extensionkit.ts
@@ -1,2 +1,2 @@
-export { createExtension } from '../extension/extension.js'
+export { createBuilderExtension, createExtension, createTypeHooks } from '../extension/extension.js'
 export { createExtension as createGeneratorExtension } from '../generator/extension/create.js'

--- a/src/extensions/SchemaErrors/runtime.ts
+++ b/src/extensions/SchemaErrors/runtime.ts
@@ -1,4 +1,4 @@
-import { createExtension, type Extension } from '../../extension/extension.js'
+import { createExtension, createTypeHooks, type Extension } from '../../extension/extension.js'
 import { Errors } from '../../lib/errors/__.js'
 import { normalizeRequestToNode } from '../../lib/grafaid/request.js'
 import { type ExcludeNullAndUndefined, isString } from '../../lib/prelude.js'
@@ -8,7 +8,7 @@ import type { GeneratedExtensions } from './global.js'
 import { injectTypenameOnRootResultFields } from './injectTypenameOnRootResultFields.js'
 
 export const SchemaErrors = () => {
-  return createExtension<SchemaErrorsExtension>({
+  return createExtension({
     name: `SchemaErrors`,
     onRequest: async ({ pack }) => {
       const state = pack.input.state
@@ -67,13 +67,12 @@ export const SchemaErrors = () => {
 
       return result
     },
+    typeHooks: createTypeHooks<{
+      onRequestDocumentRootType: OnRequestDocumentRootType_
+      onRequestResult: OnRequestResult_
+    }>,
   })
 }
-
-type SchemaErrorsExtension = Extension<{
-  onRequestDocumentRootType: OnRequestDocumentRootType_
-  onRequestResult: OnRequestResult_
-}>
 
 type OnRequestDocumentRootType<$Params extends Extension.Hooks.OnRequestDocumentRootType.Params> =
   $Params['selectionRootType']

--- a/src/extensions/Throws/Throws.ts
+++ b/src/extensions/Throws/Throws.ts
@@ -1,19 +1,14 @@
-import {
-  type AssertExtends,
-  type BuilderConfig,
-  createExtension,
-  type Extension,
-  type WithInput,
-} from '../../entrypoints/main.js'
+import { createBuilderExtension, createExtension } from '../../entrypoints/extensionkit.js'
+import { type AssertExtends, type BuilderConfig, type WithInput } from '../../entrypoints/main.js'
 import type { ConfigManager } from '../../lib/config-manager/__.js'
 // todo: no deep imports, rethink these utilities and/or how they are exported from the graffle package.
 import type { Context } from '../../layers/6_client/context.js'
-import type { Chain } from '../../lib/chain/__.js'
+import type { Builder } from '../../lib/chain/__.js'
 
 export const Throws = () => {
-  return createExtension<ThrowsExtension>({
+  return createExtension({
     name: `Throws`,
-    onBuilderGet: ({ client, property, path }) => {
+    builder: createBuilderExtension<BuilderExtension>(({ client, property, path }) => {
       if (property !== `throws` || path.length !== 0) return undefined
 
       // todo redesign input to allow to force throw always
@@ -30,20 +25,16 @@ export const Throws = () => {
         },
       }
       return () => client.with(throwsifiedInput)
-    },
+    }),
   })
 }
 
-type ThrowsExtension = Extension<{
-  chainExtension: Throws_
-}>
-
-interface Throws_ extends Chain.Extension {
+interface BuilderExtension extends Builder.Extension {
   context: Context
-  return: Throws<AssertExtends<this['params'], Chain.Extension.Parameters<Throws_>>>
+  return: BuilderExtension_<AssertExtends<this['params'], Builder.Extension.Parameters<BuilderExtension>>>
 }
 
-interface Throws<$Args extends Chain.Extension.Parameters<Throws_>> {
+interface BuilderExtension_<$Args extends Builder.Extension.Parameters<BuilderExtension>> {
   /**
    * TODO
    */

--- a/src/layers/6_client/Settings/InputToConfig.ts
+++ b/src/layers/6_client/Settings/InputToConfig.ts
@@ -11,24 +11,24 @@ export type NormalizeInput<$Input extends InputStatic> = {
   transport: HandleTransport<$Input>
   output: {
     defaults: {
-      errorChannel: ConfigManager.ReadOrDefault<$Input, ['output', 'defaults', 'errorChannel'], 'throw'>
+      errorChannel: ConfigManager.GetAtPathOrDefault<$Input, ['output', 'defaults', 'errorChannel'], 'throw'>
     }
     envelope: {
       enabled:
-						ConfigManager.Read<$Input, ['output','envelope']> 					  extends boolean 		? ConfigManager.Read<$Input, ['output','envelope']>
-					: ConfigManager.Read<$Input, ['output','envelope','enabled']>		extends boolean 		? ConfigManager.Read<$Input, ['output','envelope','enabled']>
-					: ConfigManager.Read<$Input, ['output','envelope']> 						extends object 			? true
+						ConfigManager.GetOptional<$Input, ['output','envelope']> 					  extends boolean 		? ConfigManager.GetOptional<$Input, ['output','envelope']>
+					: ConfigManager.GetOptional<$Input, ['output','envelope','enabled']>		extends boolean 		? ConfigManager.GetOptional<$Input, ['output','envelope','enabled']>
+					: ConfigManager.GetOptional<$Input, ['output','envelope']> 						extends object 			? true
 					: false
       errors: {
-        execution: ConfigManager.ReadOrDefault<$Input, ['output','envelope','errors','execution'], true>
-        other: ConfigManager.ReadOrDefault<$Input, ['output','envelope','errors','other'], false> 
-        schema: ConfigManager.ReadOrDefault<$Input, ['output','envelope','errors','schema'], false>
+        execution: ConfigManager.GetAtPathOrDefault<$Input, ['output','envelope','errors','execution'], true>
+        other: ConfigManager.GetAtPathOrDefault<$Input, ['output','envelope','errors','other'], false> 
+        schema: ConfigManager.GetAtPathOrDefault<$Input, ['output','envelope','errors','schema'], false>
       }
     }
     errors: {
-      execution: ConfigManager.ReadOrDefault<$Input,['output', 'errors', 'execution'], 'default'>
-      other: ConfigManager.ReadOrDefault<$Input,['output', 'errors', 'other'], 'default'>
-      schema: ConfigManager.ReadOrDefault<$Input,['output', 'errors', 'schema'], false>
+      execution: ConfigManager.GetAtPathOrDefault<$Input,['output', 'errors', 'execution'], 'default'>
+      other: ConfigManager.GetAtPathOrDefault<$Input,['output', 'errors', 'other'], 'default'>
+      schema: ConfigManager.GetAtPathOrDefault<$Input,['output', 'errors', 'schema'], false>
     }
   }
 }

--- a/src/layers/6_client/chainExtensions/anyware.ts
+++ b/src/layers/6_client/chainExtensions/anyware.ts
@@ -1,25 +1,25 @@
 import { createExtension } from '../../../extension/extension.js'
 import type { Anyware, Anyware as AnywareLib } from '../../../lib/anyware/__.js'
-import { Chain } from '../../../lib/chain/__.js'
+import { Builder } from '../../../lib/chain/__.js'
 import type { RequestPipeline } from '../../../requestPipeline/__.js'
 import { type Context } from '../context.js'
 
-export interface Anyware_ extends Chain.Extension {
+export interface Anyware_ extends Builder.Extension {
   context: Context
   // @ts-expect-error untyped params
   return: Anyware<this['params']>
 }
 
-export interface Anyware<$Arguments extends Chain.Extension.Parameters<Anyware_>> {
+export interface Anyware<$Arguments extends Builder.Extension.Parameters<Anyware_>> {
   /**
    * TODO Anyware Docs.
    */
   anyware: (
     anyware: AnywareLib.Extension2<RequestPipeline.Core<$Arguments['context']['config']>>,
-  ) => Chain.Definition.MaterializeWithNewContext<$Arguments['chain'], $Arguments['context']>
+  ) => Builder.Definition.MaterializeWithNewContext<$Arguments['chain'], $Arguments['context']>
 }
 
-export const AnywareExtension = Chain.Extension.create<Anyware_>((builder, context) => {
+export const AnywareExtension = Builder.Extension.create<Anyware_>((builder, context) => {
   const properties = {
     anyware: (anyware: Anyware.Extension2<RequestPipeline.Core>) => {
       return builder({

--- a/src/layers/6_client/chainExtensions/internal.ts
+++ b/src/layers/6_client/chainExtensions/internal.ts
@@ -1,13 +1,13 @@
-import type { Chain } from '../../../lib/chain/__.js'
+import type { Builder } from '../../../lib/chain/__.js'
 import type { Context } from '../context.js'
 
-export interface Internal_ extends Chain.Extension {
+export interface Internal_ extends Builder.Extension {
   context: Context
   // @ts-expect-error untyped params
   return: Internal<this['params']>
 }
 
-type Internal<$Args extends Chain.Extension.Parameters> = {
+type Internal<$Args extends Builder.Extension.Parameters> = {
   /**
    * TODO
    */

--- a/src/layers/6_client/chainExtensions/scalar.ts
+++ b/src/layers/6_client/chainExtensions/scalar.ts
@@ -1,17 +1,17 @@
 import type { Simplify } from 'type-fest'
-import { Chain } from '../../../lib/chain/__.js'
+import { Builder } from '../../../lib/chain/__.js'
 import type { ConfigManager } from '../../../lib/config-manager/__.js'
 import type { GlobalRegistry } from '../../../types/GlobalRegistry/GlobalRegistry.js'
 import { Schema } from '../../../types/Schema/__.js'
 import { type Context } from '../context.js'
 
-export interface Scalar_ extends Chain.Extension {
+export interface Scalar_ extends Builder.Extension {
   context: Context
   // @ts-expect-error untyped params
   return: Simplify<ScalarExtension<this['params']>>
 }
 
-interface ScalarExtension<$Args extends Chain.Extension.Parameters<Scalar_>> {
+interface ScalarExtension<$Args extends Builder.Extension.Parameters<Scalar_>> {
   /**
    * TODO Docs.
    */
@@ -21,7 +21,7 @@ interface ScalarExtension<$Args extends Chain.Extension.Parameters<Scalar_>> {
 export type TypeErrorMissingSchemaMap =
   `Error: Your client must have a schemaMap in order to apply registered scalars. Therefore we're providing this static error type message here instead of allowing you continue registering scalars that will never be applied.`
 
-type ScalarMethod<$Args extends Chain.Extension.Parameters<Scalar_>> = {
+type ScalarMethod<$Args extends Builder.Extension.Parameters<Scalar_>> = {
   /**
    * TODO Docs.
    */
@@ -34,7 +34,7 @@ type ScalarMethod<$Args extends Chain.Extension.Parameters<Scalar_>> = {
       decode: (value: string) => $Decoded
       encode: (value: $Decoded) => string
     },
-  ): Chain.Definition.MaterializeWithNewContext<
+  ): Builder.Definition.MaterializeWithNewContext<
     $Args['chain'],
     ConfigManager.SetAtPath<
       $Args['context'],
@@ -50,7 +50,7 @@ type ScalarMethod<$Args extends Chain.Extension.Parameters<Scalar_>> = {
    */
   <$Scalar extends Schema.Scalar<GlobalRegistry.GetOrGeneric<$Args['context']['name']>['schema']['scalarNamesUnion']>>(
     scalar: $Scalar,
-  ): Chain.Definition.MaterializeWithNewContext<
+  ): Builder.Definition.MaterializeWithNewContext<
     $Args['chain'],
     ConfigManager.SetAtPath<
       $Args['context'],
@@ -64,7 +64,7 @@ type ScalarMethod<$Args extends Chain.Extension.Parameters<Scalar_>> = {
 
 type Arguments = [Schema.Scalar] | [string, { decode: (value: string) => any; encode: (value: any) => string }]
 
-export const scalarProperties = Chain.Extension.create<Scalar_>((builder, state) => {
+export const scalarProperties = Builder.Extension.create<Scalar_>((builder, state) => {
   return {
     scalar: (...args: Arguments) => {
       const scalar = Schema.Scalar.isScalar(args[0])

--- a/src/layers/6_client/chainExtensions/use.test.ts
+++ b/src/layers/6_client/chainExtensions/use.test.ts
@@ -11,7 +11,7 @@ const headers = { 'x-foo': 'bar' }
 
 test('using an extension returns a copy of the client', () => {
   const client2 = client.use(Throws())
-  // @ts-expect-error fixme
+  // @ts-ignore fixme
   expect(client2 !== client).toBe(true)
 })
 

--- a/src/layers/6_client/chainExtensions/use.ts
+++ b/src/layers/6_client/chainExtensions/use.ts
@@ -1,22 +1,22 @@
 import type { Extension } from '../../../extension/extension.js'
-import { Chain } from '../../../lib/chain/__.js'
+import { Builder } from '../../../lib/chain/__.js'
 import type { ConfigManager } from '../../../lib/config-manager/__.js'
 import { type Context } from '../context.js'
 
-export interface Use_ extends Chain.Extension {
+export interface Use_ extends Builder.Extension {
   context: Context
   // @ts-expect-error untyped params
   return: Use<this['params']>
 }
 
-export interface Use<$Args extends Chain.Extension.Parameters<Use_>> {
+export interface Use<$Args extends Builder.Extension.Parameters<Use_>> {
   /**
    * TODO Docs.
    */
-  use: <$Extension extends Extension>(extension: $Extension) => Chain.Definition.MaterializeWithNewContext<
+  use: <$Extension extends Extension>(extension: $Extension) => Builder.Definition.MaterializeWithNewContext<
     (
-      $Extension['typeHooks']['chainExtension'] extends Chain.Extension
-        ? Chain.Definition.Extend<$Args['chain'], $Extension['typeHooks']['chainExtension']>
+      ConfigManager.GetOptional<$Extension, ['builder', 'type']> extends Builder.Extension
+        ? Builder.Definition.Extend<$Args['chain'], ConfigManager.GetOptional<$Extension, ['builder', 'type']>>
         : $Args['chain']
     ),
     // If the extension adds type hooks, merge them into the config.
@@ -36,7 +36,7 @@ export interface Use<$Args extends Chain.Extension.Parameters<Use_>> {
   >
 }
 
-export const useProperties = Chain.Extension.create<Use_>((builder, context) => {
+export const useProperties = Builder.Extension.create<Use_>((builder, context) => {
   return {
     use: (extension: Extension) => {
       return builder({

--- a/src/layers/6_client/chainExtensions/with.ts
+++ b/src/layers/6_client/chainExtensions/with.ts
@@ -1,17 +1,17 @@
-import { Chain } from '../../../lib/chain/__.js'
+import { Builder } from '../../../lib/chain/__.js'
 import type { ConfigManager } from '../../../lib/config-manager/__.js'
 import { mergeHeadersInit, mergeRequestInit } from '../../../lib/http.js'
 import { type Context } from '../context.js'
 import type { WithInput } from '../Settings/inputIncrementable/inputIncrementable.js'
 import type { NormalizeInput } from '../Settings/InputToConfig.js'
 
-export interface With_ extends Chain.Extension {
+export interface With_ extends Builder.Extension {
   context: Context
   // @ts-expect-error untyped params
   return: With<this['params']>
 }
 
-export interface With<$Args extends Chain.Extension.Parameters<With_>> {
+export interface With<$Args extends Builder.Extension.Parameters<With_>> {
   /**
    * TODO With Docs.
    */
@@ -20,7 +20,7 @@ export interface With<$Args extends Chain.Extension.Parameters<With_>> {
     // todo fixme
     // eslint-disable-next-line
     // @ts-ignore Passes after generation
-  ) => Chain.Definition.MaterializeWithNewContext<
+  ) => Builder.Definition.MaterializeWithNewContext<
     $Args['chain'],
     ConfigManager.SetProperties<
       $Args['context'],
@@ -32,7 +32,7 @@ export interface With<$Args extends Chain.Extension.Parameters<With_>> {
   >
 }
 
-export const withProperties = Chain.Extension.create<With_>((builder, state) => {
+export const withProperties = Builder.Extension.create<With_>((builder, state) => {
   return {
     with: (input: WithInput) => {
       return builder({

--- a/src/layers/6_client/client.ts
+++ b/src/layers/6_client/client.ts
@@ -1,5 +1,5 @@
 import { defaultName } from '../../generator/config/defaults.js'
-import type { Chain } from '../../lib/chain/__.js'
+import type { Builder } from '../../lib/chain/__.js'
 import type { ConfigManager } from '../../lib/config-manager/__.js'
 import { proxyGet } from '../../lib/prelude.js'
 import type { GlobalRegistry } from '../../types/GlobalRegistry/GlobalRegistry.js'
@@ -15,9 +15,9 @@ import { type RequestMethods_, requestMethodsProperties } from './requestMethods
 import { type InputStatic } from './Settings/Input.js'
 import { type NormalizeInput } from './Settings/InputToConfig.js'
 
-export type Client<$Context extends Context> = Chain.Definition.MaterializeWithNewContext<
-  Chain.Definition.ExtendMany<
-    Chain.Definition.Empty,
+export type Client<$Context extends Context> = Builder.Definition.MaterializeWithNewContext<
+  Builder.Definition.ExtendMany<
+    Builder.Definition.Empty,
     [
       Internal_,
       RequestMethods_,
@@ -82,10 +82,10 @@ export const createWithContext = (
   const clientProxy = proxyGet(clientDirect, ({ path, property }) => {
     // eslint-disable-next-line
     // @ts-ignore fixme "Type instantiation is excessively deep and possibly infinite"
-    const onGetHandlers = context.extensions.map(_ => _.onBuilderGet).filter(_ => _ !== undefined)
+    const onGetHandlers = context.extensions.map(_ => _.builder).filter(_ => _ !== undefined)
 
     for (const onGetHandler of onGetHandlers) {
-      const result = onGetHandler({
+      const result = onGetHandler.implementation({
         client: clientDirect,
         path,
         property,

--- a/src/layers/6_client/gql/gql.ts
+++ b/src/layers/6_client/gql/gql.ts
@@ -1,4 +1,4 @@
-import { Chain } from '../../../lib/chain/__.js'
+import { Builder } from '../../../lib/chain/__.js'
 import type { Grafaid } from '../../../lib/grafaid/__.js'
 import { getOperationType } from '../../../lib/grafaid/document.js'
 import {
@@ -12,19 +12,19 @@ import { handleOutput } from '../handleOutput.js'
 import type { Config } from '../Settings/Config.js'
 import { type DocumentController, resolveSendArguments, type sendArgumentsImplementation } from './send.js'
 
-export interface Gql_ extends Chain.Extension {
+export interface Gql_ extends Builder.Extension {
   context: Context
   // @ts-expect-error untyped params
   return: Gql<this['params']>
 }
 
 // dprint-ignore
-interface Gql<$Arguments extends Chain.Extension.Parameters<Gql_>> {
+interface Gql<$Arguments extends Builder.Extension.Parameters<Gql_>> {
   gql: gqlOverload<$Arguments>
 }
 
 // dprint-ignore
-interface gqlOverload<$Arguments extends Chain.Extension.Parameters<Gql_>> {
+interface gqlOverload<$Arguments extends Builder.Extension.Parameters<Gql_>> {
   <$Document extends Grafaid.Document.Typed.TypedDocumentLike>(document: $Document                            ): DocumentController<$Arguments['context'], $Document>
   <$Document extends Grafaid.Document.Typed.TypedDocumentLike>(parts: TemplateStringsArray, ...args: unknown[]): DocumentController<$Arguments['context'], $Document>
 }
@@ -38,7 +38,7 @@ const resolveGqlArguments = (args: gqlArguments) => {
   }
 }
 
-export const gqlProperties = Chain.Extension.create<Gql_>((_, context) => {
+export const gqlProperties = Builder.Extension.create<Gql_>((_, context) => {
   return {
     gql: (...args: gqlArguments) => {
       const { document: query } = resolveGqlArguments(args)

--- a/src/layers/6_client/requestMethods/requestMethods.ts
+++ b/src/layers/6_client/requestMethods/requestMethods.ts
@@ -3,7 +3,7 @@ import type { SimplifyDeep } from 'type-fest'
 import { Select } from '../../../documentBuilder/Select/__.js'
 import { SelectionSetGraphqlMapper } from '../../../documentBuilder/SelectGraphQLMapper/__.js'
 import type { TypeFunction } from '../../../entrypoints/utilities-for-generated.js'
-import { Chain } from '../../../lib/chain/__.js'
+import { Builder } from '../../../lib/chain/__.js'
 import type { Grafaid } from '../../../lib/grafaid/__.js'
 import { getOperationDefinition } from '../../../lib/grafaid/document.js'
 import { isSymbol } from '../../../lib/prelude.js'
@@ -13,14 +13,14 @@ import { type Context } from '../context.js'
 import { handleOutput } from '../handleOutput.js'
 import type { Config } from '../Settings/Config.js'
 
-export interface RequestMethods_ extends Chain.Extension {
+export interface RequestMethods_ extends Builder.Extension {
   context: Context
   // @ts-expect-error untyped params
   return: RequestMethods<this['params']>
 }
 
 // dprint-ignore
-export type RequestMethods<$Arguments extends Chain.Extension.Parameters<RequestMethods_>> =
+export type RequestMethods<$Arguments extends Builder.Extension.Parameters<RequestMethods_>> =
   SimplifyDeep<
     & (
       // todo
@@ -43,7 +43,7 @@ export type RequestMethods<$Arguments extends Chain.Extension.Parameters<Request
     )
   >
 
-export const requestMethodsProperties = Chain.Extension.create<RequestMethods_>((_, context) => {
+export const requestMethodsProperties = Builder.Extension.create<RequestMethods_>((_, context) => {
   return {
     document: createMethodDocument(context),
     query: createMethodOperationType(context, OperationTypeNode.QUERY),

--- a/src/lib/chain/__.test-d.ts
+++ b/src/lib/chain/__.test-d.ts
@@ -1,40 +1,40 @@
 import { assertEqual, assertExtends } from '../assert-equal.js'
-import type { Chain } from './__.js'
+import type { Builder } from './__.js'
 
 // ---------------------------------------------------------------------------------------------------------------------
 {
-  interface ex1_ extends Chain.Extension {
+  interface ex1_ extends Builder.Extension {
     return: {
       a: 1
     }
   }
-  type c = Chain.Definition.Extend<Chain.Definition.Empty, ex1_>
+  type c = Builder.Definition.Extend<Builder.Definition.Empty, ex1_>
   assertEqual<c['extensions'], [ex1_]>()
-  type cm = Chain.Definition.MaterializeSpecific<c>
+  type cm = Builder.Definition.MaterializeSpecific<c>
   assertEqual<cm, { a: 1 }>()
 }
 // ---------------------------------------------------------------------------------------------------------------------
 {
-  interface ex1_ extends Chain.Extension {
+  interface ex1_ extends Builder.Extension {
     return: {
       a: 1
     }
   }
-  type c = Chain.Definition.ExtendMany<Chain.Definition.Empty, [ex1_]>
+  type c = Builder.Definition.ExtendMany<Builder.Definition.Empty, [ex1_]>
   assertEqual<c['extensions'], [ex1_]>()
-  type cm = Chain.Definition.MaterializeSpecific<c>
+  type cm = Builder.Definition.MaterializeSpecific<c>
   assertEqual<cm, { a: 1 }>()
 }
 // ---------------------------------------------------------------------------------------------------------------------
 {
-  interface Reflect_ extends Chain.Extension {
+  interface Reflect_ extends Builder.Extension {
     // @ts-expect-error untyped params
     return: Reflect<this['params']>
   }
-  type Reflect<$Arguments extends Chain.Extension.Parameters> = {
+  type Reflect<$Arguments extends Builder.Extension.Parameters> = {
     reflect: keyof $Arguments
   }
-  type c = Chain.Definition.MaterializeSpecific<Chain.Definition.Extend<Chain.Definition.Empty, Reflect_>>
+  type c = Builder.Definition.MaterializeSpecific<Builder.Definition.Extend<Builder.Definition.Empty, Reflect_>>
   assertEqual<c, { reflect: 'context' | 'chain' }>()
 }
 // ---------------------------------------------------------------------------------------------------------------------
@@ -45,21 +45,24 @@ import type { Chain } from './__.js'
   interface FooContextEmpty extends FooContext {
     calls: []
   }
-  interface Foo_ extends Chain.Extension {
+  interface Foo_ extends Builder.Extension {
     context: FooContext
     contextEmpty: FooContextEmpty
     // @ts-expect-error untyped params
     return: Foo<this['params']>
   }
-  interface Foo<$Args extends Chain.Extension.Parameters<Foo_>> {
+  interface Foo<$Args extends Builder.Extension.Parameters<Foo_>> {
     _: $Args['context']
     foo: <const $Number extends number>(
       number: $Number,
-    ) => Chain.Definition.MaterializeWithNewContext<$Args['chain'], { calls: [...$Args['context']['calls'], $Number] }>
+    ) => Builder.Definition.MaterializeWithNewContext<
+      $Args['chain'],
+      { calls: [...$Args['context']['calls'], $Number] }
+    >
   }
 
-  type C = Chain.Definition.MaterializeGeneric<Chain.Definition.Extend<Chain.Definition.Empty, Foo_>>
-  type c1 = Chain.Definition.MaterializeSpecific<Chain.Definition.Extend<Chain.Definition.Empty, Foo_>>
+  type C = Builder.Definition.MaterializeGeneric<Builder.Definition.Extend<Builder.Definition.Empty, Foo_>>
+  type c1 = Builder.Definition.MaterializeSpecific<Builder.Definition.Extend<Builder.Definition.Empty, Foo_>>
 
   assertExtends<c1, C>()
 

--- a/src/lib/chain/__.ts
+++ b/src/lib/chain/__.ts
@@ -1,1 +1,1 @@
-export * as Chain from './_.js'
+export * as Builder from './_.js'

--- a/src/lib/config-manager/ConfigManager.ts
+++ b/src/lib/config-manager/ConfigManager.ts
@@ -106,8 +106,8 @@ const mergeDefaults_: MergeDefaultsInnerFn = (
 type Path = [...string[]]
 
 // dprint-ignore
-export type ReadOrDefault<$Obj, $Path extends Path, $Default> =
-  OrDefault<Read<$Obj, $Path>, $Default>
+export type GetAtPathOrDefault<$Obj, $Path extends Path, $Default> =
+  OrDefault<GetOptional<$Obj, $Path>, $Default>
 
 // dprint-ignore
 export type OrDefault<$Value, $Default> =
@@ -118,12 +118,14 @@ export type OrDefault<$Value, $Default> =
                                      $Value
 
 // dprint-ignore
-export type Read<$Value, $Path extends [...string[]]> =
-  $Value extends undefined ? undefined
-  : $Path extends [infer P1 extends string, ...infer PN extends string[]] ?
-   $Value extends object ?	P1 extends keyof $Value ? Read<$Value[P1], PN> : undefined
-              : undefined
-  : $Value
+export type GetOptional<$Value, $Path extends [...string[]]> =
+  $Value extends undefined                                              ? undefined :
+  $Path extends [infer P1 extends string, ...infer PN extends string[]] ? $Value extends object
+                                                                          ?	P1 extends keyof $Value
+                                                                            ? GetOptional<$Value[P1], PN>
+                                                                            : undefined
+                                                                          : undefined
+                                                                        : $Value
 
 /**
  * Merge new properties from the second object into the first object.


### PR DESCRIPTION
This PR makes it possible for extension authors to inline their
type extensions into the extension body. We achieve this with a new
explicit typeHooks field in the constructor input as well as a new
phantom property on builder property to supply types along with a helper
sub-constructor for hiding this nested phantom property.
