### PR TITLE
fix(generator): scalar definition name

### DIFF
--- a/src/generator/generators/Scalar.ts
+++ b/src/generator/generators/Scalar.ts
@@ -55,7 +55,7 @@ export const ModuleGeneratorScalar = createModuleGenerator(
       for (const scalar of config.schema.kindMap.list.ScalarCustom) {
         code(typeTitle2(`custom scalar type`)(scalar))
         code()
-        code(`export type ${scalar.name} = ${identifiers.$$Utilities}.Schema.Scalar.ScalarCodecless<'Date'>`)
+        code(`export type ${scalar.name} = ${identifiers.$$Utilities}.Schema.Scalar.ScalarCodecless<'${scalar.name}'>`)
         // code(`import type { String as ${scalar.name} } from '${config.paths.imports.grafflePackage.scalars}'`)
         // code()
         // code(`export { String as ${scalar.name} } from '${config.paths.imports.grafflePackage.scalars}'`)


### PR DESCRIPTION
ACTUALLY closes #1228

 

We need to add one more scalar to the tests to avoid not catching this. Hardcoding to date never broke the tests since they used... Date. 🤦.


Thank you @ziimakc.