### PR TITLE
Fix broken documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,26 +107,26 @@ await client.request(document)
 ## Examples
 
 - Request:
-  - [Authentication via HTTP header](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/request-authentication-via-http-header.ts)
-  - [Method GET](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/request-method-get.ts)
-  - [Cancellation](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/request-cancellation.ts)
-  - [Headers Per Request (static)](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/request-headers-static-per-request.ts)
-  - [Headers Per Request (dynamic)](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/request-headers-dynamic-per-request.ts)
-  - [Handle Raw Response](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/request-handle-raw-response.ts)
+  - [Authentication via HTTP header](https://github.com/graffle-js/graffle/tree/graphql-request/examples/request-authentication-via-http-header.ts)
+  - [Method GET](https://github.com/graffle-js/graffle/tree/graphql-request/examples/request-method-get.ts)
+  - [Cancellation](https://github.com/graffle-js/graffle/tree/graphql-request/examples/request-cancellation.ts)
+  - [Headers Per Request (static)](https://github.com/graffle-js/graffle/tree/graphql-request/examples/request-headers-static-per-request.ts)
+  - [Headers Per Request (dynamic)](https://github.com/graffle-js/graffle/tree/graphql-request/examples/request-headers-dynamic-per-request.ts)
+  - [Handle Raw Response](https://github.com/graffle-js/graffle/tree/graphql-request/examples/request-handle-raw-response.ts)
 - GraphQL:
-  - [Document Variables](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/graphql-document-variables.ts)
-  - [Mutation](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/graphql-mutations.ts)
-  - [Batching Requests](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/graphql-batching-requests.ts)
+  - [Document Variables](https://github.com/graffle-js/graffle/tree/graphql-request/examples/graphql-document-variables.ts)
+  - [Mutation](https://github.com/graffle-js/graffle/tree/graphql-request/examples/graphql-mutations.ts)
+  - [Batching Requests](https://github.com/graffle-js/graffle/tree/graphql-request/examples/graphql-batching-requests.ts)
 - Configuration:
-  - [Fetch: Passing Options](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/configuration-fetch-options.ts)
-  - [Custom JSON Serializer](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/configuration-request-json-serializer.ts)
-  - [Incremental: Set Endpoint](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/configuration-incremental-endpoint.ts)
-  - [Incremental: Set Request Headers](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/configuration-incremental-request-headers.ts)
+  - [Fetch: Passing Options](https://github.com/graffle-js/graffle/tree/graphql-request/examples/configuration-fetch-options.ts)
+  - [Custom JSON Serializer](https://github.com/graffle-js/graffle/tree/graphql-request/examples/configuration-request-json-serializer.ts)
+  - [Incremental: Set Endpoint](https://github.com/graffle-js/graffle/tree/graphql-request/examples/configuration-incremental-endpoint.ts)
+  - [Incremental: Set Request Headers](https://github.com/graffle-js/graffle/tree/graphql-request/examples/configuration-incremental-request-headers.ts)
 - TypeScript:
-  - [Use `TypedDocumentNode`](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/typescript-typed-document-node.ts)
+  - [Use `TypedDocumentNode`](https://github.com/graffle-js/graffle/tree/graphql-request/examples/typescript-typed-document-node.ts)
 - Other:
-  - [Middleware](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/other-middleware.ts)
-  - [Error Handling](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/other-error-handling.ts)
+  - [Middleware](https://github.com/graffle-js/graffle/tree/graphql-request/examples/other-middleware.ts)
+  - [Error Handling](https://github.com/graffle-js/graffle/tree/graphql-request/examples/other-error-handling.ts)
 
 ## Node Version Support
 
@@ -142,7 +142,7 @@ Any issue that exists solely for an unsupported version of Nodejs will be reject
 
 ## Reference
 
-⚠️ This reference is incomplete. Check out the [examples](https://github.com/graffle-js/graffle/tree/graphql-request/examples/legacy/) for more reference material.
+⚠️ This reference is incomplete. Check out the [examples](https://github.com/graffle-js/graffle/tree/graphql-request/examples/) for more reference material.
 
 ### Configuration
 


### PR DESCRIPTION
Documentation links have been broken both on Github and NPM due to `/legacy` being included in the urls. 

This PR removes the `/legacy` paths to make them functional again.

All links changed have been tested. 