### PR TITLE
improve(anyware): extensions

### DIFF
--- a/examples/__outputs__/20_output/output_preset__standard-graphql.output.txt
+++ b/examples/__outputs__/20_output/output_preset__standard-graphql.output.txt
@@ -13,14 +13,14 @@ ContextualError: There was an error in the core implementation of hook "exchange
   context: { hookName: 'exchange', source: 'implementation' },
   [cause]: TypeError: Failed to parse URL from ...
       at new Request (node:internal/deps/undici/undici:XX:XX)
-      at Object.run (/some/path/to/RequestPipeline.ts:XX:XX:27)
+      at Object.run (/some/path/to/httpTransport.ts:XX:XX:27)
       ... 6 lines matching cause stack trace ...
       at async Module.run (/some/path/to/run.ts:XX:XX:10)
       at async Object.send (/some/path/to/gql.ts:XX:XX:26) {
     [cause]: TypeError: Invalid URL
         at new URL (node:internal/url:XX:XX)
         at new Request (node:internal/deps/undici/undici:XX:XX)
-        at Object.run (/some/path/to/RequestPipeline.ts:XX:XX:27)
+        at Object.run (/some/path/to/httpTransport.ts:XX:XX:27)
         at Object.run (/some/path/to/builder.ts:XX:XX:53)
         at runStep (/some/path/to/runStep.ts:XX:XX:37)
         at runPipeline (/some/path/to/runPipeline.ts:XX:XX:8)

--- a/src/lib/anyware/Extension/Builder.ts
+++ b/src/lib/anyware/Extension/Builder.ts
@@ -1,0 +1,31 @@
+import type { ConfigManager } from '../../config-manager/__.js'
+import type { Overload } from '../Overload/__.js'
+import type { Pipeline } from '../Pipeline/__.js'
+
+export interface Builder<
+  $PipelineContext extends Pipeline.Context = Pipeline.Context,
+  $Context extends Context = Context,
+> {
+  context: $Context
+  /**
+   * TODO
+   */
+  overload: <$OverloadBuilder extends Overload.Builder<$PipelineContext>>(
+    overloadBuilder: Overload.BuilderCallback<$PipelineContext, $OverloadBuilder>,
+  ) => Builder<
+    $PipelineContext,
+    ConfigManager.AppendAtKey<
+      $Context,
+      'overloads',
+      $OverloadBuilder['context']
+    >
+  >
+}
+
+export interface Context {
+  overloads: Overload.BuilderContext[]
+}
+
+export interface ContextEmpty extends Context {
+  overloads: []
+}

--- a/src/lib/anyware/Extension/Extension.ts
+++ b/src/lib/anyware/Extension/Extension.ts
@@ -1,0 +1,25 @@
+import { __ } from '../../prelude.js'
+import { Overload } from '../Overload/__.js'
+import type { Pipeline } from '../Pipeline/__.js'
+import type { Builder, Context, ContextEmpty } from './Builder.js'
+
+export * from './Builder.js'
+
+export const create: Create = () => {
+  const context: Context = {
+    overloads: [],
+  }
+
+  const builder: Builder = {
+    context,
+    overload: (builderCallback) => {
+      const overload = builderCallback({ create: Overload.create })
+      context.overloads.push(overload.context)
+      return builder as any
+    },
+  }
+
+  return builder as any
+}
+
+type Create = <$PipelineContext extends Pipeline.Context>() => Builder<$PipelineContext, ContextEmpty>

--- a/src/lib/anyware/Extension/__.ts
+++ b/src/lib/anyware/Extension/__.ts
@@ -1,0 +1,1 @@
+export * as Extension from './Extension.js'

--- a/src/lib/anyware/Overload/Builder.ts
+++ b/src/lib/anyware/Overload/Builder.ts
@@ -1,0 +1,103 @@
+import type { ConfigManager } from '../../config-manager/__.js'
+import type { Tuple } from '../../prelude.js'
+import type { Pipeline } from '../Pipeline/__.js'
+import type { Step } from '../Step.js'
+
+export interface Builder<
+  $RootContext extends Pipeline.Context = Pipeline.Context,
+  $Context extends BuilderContext = BuilderContextEmpty,
+> {
+  context: $Context
+  /**
+   * TODO
+   */
+  step: BuilderStep<$RootContext, $Context>
+  /**
+   * TODO
+   */
+  extendInput: <$InputExtension extends object>() => Builder<
+    $RootContext,
+    ConfigManager.UpdateOneKey<$Context, 'input', $InputExtension>
+  >
+  /**
+   * TODO
+   */
+  stepWithExtendedInput: <$InputExtension extends object>() => BuilderStep<
+    $RootContext,
+    $Context,
+    $InputExtension
+  >
+}
+
+interface BuilderStep<
+  $RootContext extends Pipeline.Context,
+  $Context extends BuilderContext,
+  $InputExtension extends object = {},
+> {
+  <
+    $Name extends $RootContext['steps'][number]['name'],
+    $Slots extends undefined | Step.Slots = undefined,
+    $Input =
+      & InferStepInput<
+        $Context,
+        Extract<$RootContext['steps'][number], { name: $Name }>,
+        Tuple.PreviousItem<$RootContext['steps'], { name: $Name }>
+      >
+      & $InputExtension,
+    $Output = unknown,
+  >(
+    name: $Name,
+    spec: {
+      slots?: $Slots
+      run: (input: $Input, slots: $Slots) => $Output
+    },
+  ): Builder<
+    $RootContext,
+    ConfigManager.UpdateOneKey<
+      $Context,
+      'steps',
+      & $Context['steps']
+      & {
+        [_ in $Name]: {
+          name: $Name
+          input: $Input
+          output: Awaited<$Output>
+          slots: ConfigManager.OrDefault2<$Slots, {}>
+        }
+      }
+    >
+  >
+}
+
+// dprint-ignore
+type InferStepInput<
+  $OverloadContext extends BuilderContext,
+  $CurrentStep extends Step,
+  $PreviousStep extends Step | undefined,
+> =
+  $PreviousStep extends Step
+    ? $PreviousStep['name'] extends keyof $OverloadContext['steps']
+      ? $OverloadContext['steps'][$PreviousStep['name']]['output']
+      :
+        & $CurrentStep['input']
+        & $OverloadContext['input']
+        & { [_ in $OverloadContext['discriminant'][0]]: $OverloadContext['discriminant'][1] }
+      :
+        & $CurrentStep['input']
+        & $OverloadContext['input']
+        & { [_ in $OverloadContext['discriminant'][0]]: $OverloadContext['discriminant'][1] }
+
+export interface BuilderContext {
+  discriminant: DiscriminantSpec
+  input: object
+  steps: Record<string, Step>
+}
+
+export type DiscriminantSpec = readonly [string, DiscriminantPropertyValue]
+
+export type DiscriminantPropertyValue = string | number | symbol
+
+interface BuilderContextEmpty extends BuilderContext {
+  input: {}
+  steps: {}
+}

--- a/src/lib/anyware/Overload/Overload.ts
+++ b/src/lib/anyware/Overload/Overload.ts
@@ -1,0 +1,49 @@
+import type { Pipeline } from '../Pipeline/__.js'
+import type { Step } from '../Step.js'
+import type { Overload } from './__.js'
+import type { Builder, BuilderContext, DiscriminantSpec } from './Builder.js'
+
+export * from './Builder.js'
+
+export const create: Create = (parameters) => {
+  const context_: Omit<BuilderContext, 'input'> = {
+    discriminant: parameters.discriminant,
+    steps: {},
+  }
+  const context = context_ as BuilderContext
+
+  const builder: Builder = {
+    context,
+    extendInput: () => builder as any,
+    stepWithExtendedInput: () => builder.step as any,
+    step: (name, spec) => {
+      context.steps[name] = {
+        name,
+        ...spec,
+      } as unknown as Step
+      return builder as any
+    },
+  }
+
+  return builder as any
+}
+
+export type Create<$RootContext extends Pipeline.Context = Pipeline.Context> = <
+  const $DiscriminantSpec extends DiscriminantSpec,
+>(
+  parameters: { discriminant: $DiscriminantSpec },
+) => Builder<
+  $RootContext,
+  {
+    discriminant: $DiscriminantSpec
+    input: {}
+    steps: {}
+  }
+>
+
+export type BuilderCallback<
+  $Context extends Pipeline.Context,
+  $OverloadBuilder extends Builder<$Context>,
+> = (
+  overloadBuilder: { create: Overload.Create<$Context> },
+) => $OverloadBuilder

--- a/src/lib/anyware/Overload/__.ts
+++ b/src/lib/anyware/Overload/__.ts
@@ -1,0 +1,1 @@
+export * as Overload from './Overload.js'

--- a/src/lib/anyware/Pipeline/builder.test-d.ts
+++ b/src/lib/anyware/Pipeline/builder.test-d.ts
@@ -126,10 +126,13 @@ describe(`overload`, () => {
         [{ discriminant: d; input: {}; steps: {} }]
       >()
     })
-    test(`overload constructor with input and discriminant`, () => {
-      expectTypeOf(b0.overload(o => o.createWithInput<{ x: 1 }>()({ discriminant: d })).context.overloads)
-        .toMatchTypeOf<[{ discriminant: d; input: { x: 1 }; steps: {} }]>()
-    })
+  })
+
+  // overload extends input
+
+  test(`overload constructor with input and discriminant`, () => {
+    expectTypeOf(b0.overload(o => o.create({ discriminant: d }).extendInput<{ x: 1 }>()).context.overloads)
+      .toMatchTypeOf<[{ discriminant: d; input: { x: 1 }; steps: {} }]>()
   })
 
   // step
@@ -171,7 +174,7 @@ describe(`overload`, () => {
   test(`can extend input type`, () => {
     expectTypeOf(
       b0.step(`a`).overload(o =>
-        o.create({ discriminant: d }).stepWithInputExtension<{ ex: 1 }>()(`a`, {
+        o.create({ discriminant: d }).stepWithExtendedInput<{ ex: 1 }>()(`a`, {
           run: (input) => {
             expectTypeOf(input).toEqualTypeOf<initialInput & dObject & { ex: 1 }>()
           },
@@ -242,11 +245,11 @@ describe(`overload`, () => {
 
   // Overloads Merging Into Pipeline
 
-  test(`overload inputs become a pipeline union input`, () => {
+  test(`overload input extensions become a pipeline union input`, () => {
     const p = b0
       .step(`a`)
-      .overload(o => o.createWithInput<{ ol1: 1 }>()({ discriminant: d }))
-      .overload(o => o.createWithInput<{ ol2: 2 }>()({ discriminant: d2 }))
+      .overload(o => o.create({ discriminant: d }).extendInput<{ ol1: 1 }>())
+      .overload(o => o.create({ discriminant: d2 }).extendInput<{ ol2: 2 }>())
       .done()
     expectTypeOf(p.input).toMatchTypeOf<
       | (initialInput & dObject & { ol1: 1 })

--- a/src/lib/anyware/Step.ts
+++ b/src/lib/anyware/Step.ts
@@ -46,7 +46,8 @@ export namespace Step {
 
   export type Runner<
     $Input extends Input = Input,
-    $Slots extends undefined | Step.Slots = undefined,
+    // $Slots extends undefined | Step.Slots = undefined,
+    $Slots extends undefined | object = undefined,
     $Previous extends undefined | object = undefined,
     $Output = any,
   > = (

--- a/src/lib/anyware/_.ts
+++ b/src/lib/anyware/_.ts
@@ -1,3 +1,4 @@
+export * from './Extension/__.js'
 export * from './Interceptor/Interceptor.js'
 export * from './Pipeline/__.js'
 export * from './Pipeline/Spec.js'

--- a/src/lib/anyware/run/run.test.ts
+++ b/src/lib/anyware/run/run.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-import { beforeEach, describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { Errors } from '../../errors/__.js'
 import type { ContextualError } from '../../errors/ContextualError.js'
 import { Pipeline } from '../_.js'
@@ -13,7 +13,7 @@ import {
   runRetrying,
   type TestInterceptor,
 } from '../__.test-helpers.js'
-import { type ResultSuccess, successfulResult } from '../Pipeline/Result.js'
+import { successfulResult } from '../Pipeline/Result.js'
 import { Step } from '../Step.js'
 
 describe(`no interceptors`, () => {
@@ -36,15 +36,14 @@ describe(`one extension`, () => {
     expect(pipeline.stepsIndex.get('a')?.run).toHaveBeenCalled()
     expect(pipeline.stepsIndex.get('b')?.run).toHaveBeenCalled()
   })
-  test('can call hook with no input, making the original input be used', () => {
-    expect(
+  test('can call hook with no input, making the original input be used', async () => {
+    await expect(
       run(async ({ a }) => {
         return await a()
       }),
     ).resolves.toEqual({ value: { value: 'initial+a+b' } })
-    // todo why doesn't this work?
-    // expect(core.hooks.a).toHaveBeenCalled()
-    // expect(core.hooks.b).toHaveBeenCalled()
+    expect(pipeline.stepsIndex.get('a')?.run).toHaveBeenCalled()
+    expect(pipeline.stepsIndex.get('b')?.run).toHaveBeenCalled()
   })
   describe(`can short-circuit`, () => {
     test(`at start, return input`, async () => {
@@ -270,18 +269,18 @@ describe(`errors`, () => {
       }).step(stepA).done()
 
       // dprint-ignore
-      expect(Pipeline.run(builder, { initialInput: { throws: new Error('oops') }, interceptors: [] })).resolves.toBeInstanceOf(Errors.ContextualError)
+      await expect(Pipeline.run(builder, { initialInput: { throws: new Error('oops') }, interceptors: [] })).resolves.toBeInstanceOf(Errors.ContextualError)
       // dprint-ignore
-      expect(Pipeline.run(builder, { initialInput: { throws: new SpecialError1('oops') }, interceptors: [] })).resolves.toBeInstanceOf(SpecialError1)
+      await expect(Pipeline.run(builder, { initialInput: { throws: new SpecialError1('oops') }, interceptors: [] })).resolves.toBeInstanceOf(SpecialError1)
     })
     test('via passthroughErrorInstanceOf (multiple)', async () => {
       const builder = Pipeline.create<{ throws: Error }>({
         passthroughErrorInstanceOf: [SpecialError1, SpecialError2],
       }).step(stepA).done()
       // dprint-ignore
-      expect(Pipeline.run(builder, { initialInput: { throws: new Error('oops') }, interceptors: [] })).resolves.toBeInstanceOf(Errors.ContextualError)
+      await expect(Pipeline.run(builder, { initialInput: { throws: new Error('oops') }, interceptors: [] })).resolves.toBeInstanceOf(Errors.ContextualError)
       // dprint-ignore
-      expect(Pipeline.run(builder, { initialInput: { throws: new SpecialError2('oops') }, interceptors: [] })).resolves.toBeInstanceOf(SpecialError2)
+      await expect(Pipeline.run(builder, { initialInput: { throws: new SpecialError2('oops') }, interceptors: [] })).resolves.toBeInstanceOf(SpecialError2)
     })
     test('via passthroughWith', async () => {
       const builder = Pipeline.create<{ throws: Error }>({
@@ -292,9 +291,9 @@ describe(`errors`, () => {
         },
       }).step(stepA).done()
       // dprint-ignore
-      expect(Pipeline.run(builder, { initialInput: { throws: new Error('oops') }, interceptors: [] })).resolves.toBeInstanceOf(Errors.ContextualError)
+      await expect(Pipeline.run(builder, { initialInput: { throws: new Error('oops') }, interceptors: [] })).resolves.toBeInstanceOf(Errors.ContextualError)
       // dprint-ignore
-      expect(Pipeline.run(builder, { initialInput: { throws: new SpecialError1('oops') }, interceptors: [] })).resolves.toBeInstanceOf(SpecialError1)
+      await expect(Pipeline.run(builder, { initialInput: { throws: new SpecialError1('oops') }, interceptors: [] })).resolves.toBeInstanceOf(SpecialError1)
     })
   })
 })

--- a/src/lib/config-manager/ConfigManager.ts
+++ b/src/lib/config-manager/ConfigManager.ts
@@ -159,6 +159,10 @@ export type AppendAtKey<$Obj extends object, $Prop extends keyof $Obj, $Type> =
   // @ts-expect-error
   UpdateOneKey<$Obj, $Prop, [...$Obj[$Prop], $Type]>
 
+export type AppendManyAtKey<$Obj extends object, $Prop extends keyof $Obj, $Type extends any[]> =
+  // @ts-expect-error
+  UpdateOneKey<$Obj, $Prop, [...$Obj[$Prop], ...$Type]>
+
 export type UpdateOneKey<$Obj extends object, $Prop extends keyof $Obj, $Type extends $Obj[$Prop]> =
   & {
     [_ in keyof $Obj as _ extends $Prop ? never : _]: $Obj[_]

--- a/src/lib/prelude.ts
+++ b/src/lib/prelude.ts
@@ -698,7 +698,12 @@ export type SimplifyExcept<$ExcludeType, $Type> =
       ? $Type
       : {[TypeKey in keyof $Type]: $Type[TypeKey]}
 
+export const __: () => never = () => {
+  throw new Error(`not implemented`)
+}
+
 export const _ = undefined as any
+
 export type _ = typeof _
 
 // dprint-ignore

--- a/src/requestPipeline/RequestPipeline.ts
+++ b/src/requestPipeline/RequestPipeline.ts
@@ -1,22 +1,15 @@
 import type { FormattedExecutionResult } from 'graphql'
 import type { Context } from '../client/context.js'
-import { MethodMode, type MethodModeGetReads } from '../client/transportHttp/request.js'
-import type { MethodModePost } from '../client/transportHttp/request.js'
 import { Anyware } from '../lib/anyware/__.js'
 import type { Grafaid } from '../lib/grafaid/__.js'
-import { OperationTypeToAccessKind, print } from '../lib/grafaid/document.js'
-import { execute } from '../lib/grafaid/execute.js' // todo
-import { getRequestEncodeSearchParameters, postRequestEncodeBody } from '../lib/grafaid/http/http.js'
-import { getRequestHeadersRec, parseExecutionResult, postRequestHeadersRec } from '../lib/grafaid/http/http.js'
 import { normalizeRequestToNode } from '../lib/grafaid/request.js'
-import { mergeRequestInit, searchParamsAppendAll } from '../lib/http.js'
-import type { httpMethodGet, httpMethodPost } from '../lib/http.js'
-import { _, isAbortError, isString, type MaybePromise } from '../lib/prelude.js'
-import { Transport } from '../types/Transport.js'
+import { isAbortError } from '../lib/prelude.js'
 import { decodeResultData } from './CustomScalars/decode.js'
 import { encodeRequestVariables } from './CustomScalars/encode.js'
+import { httpTransport } from './extensions/httpTransport.js'
+import { memoryTransport } from './extensions/memoryTransport.js'
 
-export const requestPipeline = Anyware.Pipeline
+const requestPipelineBase = Anyware.Pipeline
   .create<{
     request: Grafaid.RequestAnalyzedInput
     state: Context
@@ -80,160 +73,17 @@ export const requestPipeline = Anyware.Pipeline
           response: input.response,
         }
         : input.result
-
-      // return input.result
     },
   })
-  .overload((overload) =>
-    overload
-      .createWithInput<{ url: URL | string }>()({
-        discriminant: [`transportType`, `http`],
-      })
-      .stepWithInputExtension<{ headers?: HeadersInit }>()(`pack`, {
-        slots: {
-          searchParams: getRequestEncodeSearchParameters,
-          body: postRequestEncodeBody,
-        },
-        run: (input, slots) => {
-          const graphqlRequest: Grafaid.HTTP.RequestConfig = {
-            operationName: input.request.operationName,
-            variables: input.request.variables,
-            query: print(input.request.query),
-          }
 
-          if (input.state.config.transport.type !== Transport.http) throw new Error(`transport type is not http`)
+export type RequestPipelineBaseContext = typeof requestPipelineBase['context']
 
-          const operationType = isString(input.request.operation)
-            ? input.request.operation
-            : input.request.operation.operation
-          const methodMode = input.state.config.transport.config.methodMode
-          const requestMethod = methodMode === MethodMode.post
-            ? `post`
-            : OperationTypeToAccessKind[operationType] === `read`
-            ? `get`
-            : `post`
-
-          const baseProperties = mergeRequestInit(
-            mergeRequestInit(
-              mergeRequestInit(
-                {
-                  headers: requestMethod === `get` ? getRequestHeadersRec : postRequestHeadersRec,
-                },
-                {
-                  headers: input.state.config.transport.config.headers,
-                },
-              ),
-              input.state.config.transport.config.raw,
-            ),
-            {
-              headers: input.headers,
-            },
-          )
-          const request: ExchangeRequest = requestMethod === `get`
-            ? {
-              methodMode: methodMode as MethodModeGetReads,
-              ...baseProperties,
-              method: `get`,
-              url: searchParamsAppendAll(input.url, slots.searchParams(graphqlRequest)),
-            }
-            : {
-              methodMode: methodMode,
-              ...baseProperties,
-              method: `post`,
-              url: input.url,
-              body: slots.body(graphqlRequest),
-            }
-          return {
-            ...input,
-            request,
-          }
-        },
-      })
-      .step(`exchange`, {
-        slots: {
-          fetch: (requestInfo: RequestInfo): MaybePromise<Response> => fetch(requestInfo),
-        },
-        run: async (input, slots) => {
-          const request = new Request(input.request.url, input.request)
-          const response = await slots.fetch(request)
-          return {
-            ...input,
-            response,
-          }
-        },
-      })
-      .step(`unpack`, {
-        run: async (input) => {
-          // todo 1 if response is missing header of content length then .json() hangs forever.
-          //        firstly consider a timeout, secondly, if response is malformed, then don't even run .json()
-          // todo 2 if response is e.g. 404 with no json body, then an error is thrown because json parse cannot work, not gracefully handled here
-          const json = await input.response.json() as object
-          const result = parseExecutionResult(json)
-          return {
-            ...input,
-            result,
-          }
-        },
-      })
-  )
-  .overload((overload) =>
-    overload
-      .createWithInput<{ schema: Grafaid.Schema.Schema }>()({
-        discriminant: [`transportType`, `memory`],
-      })
-      .step(`pack`, {
-        run: (input) => {
-          const graphqlRequest: Grafaid.HTTP.RequestConfig = {
-            operationName: input.request.operationName,
-            variables: input.request.variables,
-            query: print(input.request.query),
-          }
-          return {
-            ...input,
-            request: graphqlRequest,
-          }
-        },
-      })
-      .step(`exchange`, {
-        run: async (input) => {
-          const result = await execute(input)
-          return {
-            ...input,
-            result,
-          }
-        },
-      })
-      .step(`unpack`, {
-        run: (input) => {
-          return input
-          // return {
-          //   ...input,
-          //   result: input.result,
-          // }
-        },
-      })
-  )
+export const requestPipeline = requestPipelineBase
+  .use(httpTransport)
+  .use(memoryTransport)
   .done()
 
 export type RequestPipeline = typeof requestPipeline
-
-type ExchangeRequest = ExchangePostRequest | ExchangeGetRequest
-
-/**
- * An extension of {@link RequestInit} that adds a required `url` property and makes `body` required.
- */
-type ExchangePostRequest = Omit<RequestInit, 'body' | 'method'> & {
-  methodMode: MethodModePost | MethodModeGetReads
-  method: httpMethodPost
-  url: string | URL // todo URL for config and string only for input. Requires anyware to allow different types for input and existing config.
-  body: BodyInit
-}
-
-type ExchangeGetRequest = Omit<RequestInit, 'body' | 'method'> & {
-  methodMode: MethodModeGetReads
-  method: httpMethodGet
-  url: string | URL
-}
 
 export namespace requestPipeline {
   export type ResultFailure = Anyware.Pipeline.ResultFailure

--- a/src/requestPipeline/extensions/httpTransport.ts
+++ b/src/requestPipeline/extensions/httpTransport.ts
@@ -1,0 +1,126 @@
+import { MethodMode, type MethodModeGetReads } from '../../client/transportHttp/request.js'
+import type { MethodModePost } from '../../client/transportHttp/request.js'
+import { Anyware } from '../../lib/anyware/__.js'
+import type { Grafaid } from '../../lib/grafaid/__.js'
+import { OperationTypeToAccessKind, print } from '../../lib/grafaid/document.js'
+import { getRequestEncodeSearchParameters, postRequestEncodeBody } from '../../lib/grafaid/http/http.js'
+import { getRequestHeadersRec, parseExecutionResult, postRequestHeadersRec } from '../../lib/grafaid/http/http.js'
+import { mergeRequestInit, searchParamsAppendAll } from '../../lib/http.js'
+import type { httpMethodGet, httpMethodPost } from '../../lib/http.js'
+import { _, isString, type MaybePromise } from '../../lib/prelude.js'
+import { Transport } from '../../types/Transport.js'
+import type { RequestPipelineBaseContext } from '../RequestPipeline.js'
+
+export const httpTransport = Anyware.Extension
+  .create<RequestPipelineBaseContext>()
+  .overload(overload =>
+    overload
+      .create({
+        discriminant: [`transportType`, `http`],
+      })
+      .extendInput<{ url: URL | string }>()
+      .stepWithExtendedInput<{ headers?: HeadersInit }>()(`pack`, {
+        slots: {
+          searchParams: getRequestEncodeSearchParameters,
+          body: postRequestEncodeBody,
+        },
+        run: (input, slots) => {
+          const graphqlRequest: Grafaid.HTTP.RequestConfig = {
+            operationName: input.request.operationName,
+            variables: input.request.variables,
+            query: print(input.request.query),
+          }
+
+          if (input.state.config.transport.type !== Transport.http) throw new Error(`transport type is not http`)
+
+          const operationType = isString(input.request.operation)
+            ? input.request.operation
+            : input.request.operation.operation
+          const methodMode = input.state.config.transport.config.methodMode
+          const requestMethod = methodMode === MethodMode.post
+            ? `post`
+            : OperationTypeToAccessKind[operationType] === `read`
+            ? `get`
+            : `post`
+
+          const baseProperties = mergeRequestInit(
+            mergeRequestInit(
+              mergeRequestInit(
+                {
+                  headers: requestMethod === `get` ? getRequestHeadersRec : postRequestHeadersRec,
+                },
+                {
+                  headers: input.state.config.transport.config.headers,
+                },
+              ),
+              input.state.config.transport.config.raw,
+            ),
+            {
+              headers: input.headers,
+            },
+          )
+          const request: ExchangeRequest = requestMethod === `get`
+            ? {
+              methodMode: methodMode as MethodModeGetReads,
+              ...baseProperties,
+              method: `get`,
+              url: searchParamsAppendAll(input.url, slots.searchParams(graphqlRequest)),
+            }
+            : {
+              methodMode: methodMode,
+              ...baseProperties,
+              method: `post`,
+              url: input.url,
+              body: slots.body(graphqlRequest),
+            }
+          return {
+            ...input,
+            request,
+          }
+        },
+      })
+      .step(`exchange`, {
+        slots: {
+          fetch: (requestInfo: RequestInfo): MaybePromise<Response> => fetch(requestInfo),
+        },
+        run: async (input, slots) => {
+          const request = new Request(input.request.url, input.request)
+          const response = await slots.fetch(request)
+          return {
+            ...input,
+            response,
+          }
+        },
+      })
+      .step(`unpack`, {
+        run: async (input) => {
+          // todo 1 if response is missing header of content length then .json() hangs forever.
+          //        firstly consider a timeout, secondly, if response is malformed, then don't even run .json()
+          // todo 2 if response is e.g. 404 with no json body, then an error is thrown because json parse cannot work, not gracefully handled here
+          const json = await input.response.json() as object
+          const result = parseExecutionResult(json)
+          return {
+            ...input,
+            result,
+          }
+        },
+      })
+  )
+
+type ExchangeRequest = ExchangePostRequest | ExchangeGetRequest
+
+/**
+ * An extension of {@link RequestInit} that adds a required `url` property and makes `body` required.
+ */
+type ExchangePostRequest = Omit<RequestInit, 'body' | 'method'> & {
+  methodMode: MethodModePost | MethodModeGetReads
+  method: httpMethodPost
+  url: string | URL // todo URL for config and string only for input. Requires anyware to allow different types for input and existing config.
+  body: BodyInit
+}
+
+type ExchangeGetRequest = Omit<RequestInit, 'body' | 'method'> & {
+  methodMode: MethodModeGetReads
+  method: httpMethodGet
+  url: string | URL
+}

--- a/src/requestPipeline/extensions/memoryTransport.ts
+++ b/src/requestPipeline/extensions/memoryTransport.ts
@@ -1,0 +1,41 @@
+import { Anyware } from '../../lib/anyware/__.js'
+import type { Grafaid } from '../../lib/grafaid/__.js'
+import { print } from '../../lib/grafaid/document.js'
+import { execute } from '../../lib/grafaid/execute.js' // todo
+import type { RequestPipelineBaseContext } from '../RequestPipeline.js'
+
+export const memoryTransport = Anyware.Extension
+  .create<RequestPipelineBaseContext>()
+  .overload(overload =>
+    overload
+      .create({
+        discriminant: [`transportType`, `memory`],
+      })
+      .extendInput<{ schema: Grafaid.Schema.Schema }>()
+      .step(`pack`, {
+        run: (input) => {
+          const graphqlRequest: Grafaid.HTTP.RequestConfig = {
+            operationName: input.request.operationName,
+            variables: input.request.variables,
+            query: print(input.request.query),
+          }
+          return {
+            ...input,
+            request: graphqlRequest,
+          }
+        },
+      })
+      .step(`exchange`, {
+        run: async (input) => {
+          const result = await execute(input)
+          return {
+            ...input,
+            result,
+          }
+        },
+      })
+      // todo this should not be needed, default is already a passthrough.
+      .step(`unpack`, {
+        run: (input) => input,
+      })
+  )


### PR DESCRIPTION
Progresses https://github.com/graffle-js/graffle/issues/1236

This PR brings extensions to anyware. The HTTP and Memory transports are moved to being anyware extensions now. The next step is to lift them one level up into Graffle extensions. This will require the ability to statically apply anyware extensions (should be fairly simple).

