### PR TITLE
fix(generator): use dynamic root type names in SelectionSets.ts

### DIFF
--- a/src/generator/generators/SelectionSets.test.ts
+++ b/src/generator/generators/SelectionSets.test.ts
@@ -27,7 +27,7 @@ describe('custom root type names', () => {
       type QueryRoot { x: String }
       type MutationRoot { y: String }
     `)
-    
+
     expect(doc).toContain('QueryRoot<_$Scalars>')
     expect(doc).toContain('MutationRoot<_$Scalars>')
     expect(doc).not.toContain(': Query<')
@@ -39,7 +39,7 @@ describe('custom root type names', () => {
       type Query { x: String }
       type Mutation { y: String }
     `)
-    
+
     expect(doc).toContain('Query<_$Scalars>')
     expect(doc).toContain('Mutation<_$Scalars>')
   })
@@ -49,7 +49,7 @@ describe('custom root type names', () => {
       schema { query: MyQuery }
       type MyQuery { x: String }
     `)
-    
+
     expect(doc).toContain('MyQuery<_$Scalars>')
     expect(doc).not.toContain('mutation?:')
   })

--- a/src/generator/generators/SelectionSets.test.ts
+++ b/src/generator/generators/SelectionSets.test.ts
@@ -1,0 +1,100 @@
+import * as MemFS from 'memfs'
+import * as Fs from 'node:fs/promises'
+import { beforeEach, describe, expect, test } from 'vitest'
+import { generate } from '../generator/generate.js'
+
+const fs = MemFS.fs.promises as any as typeof Fs
+
+const readGeneratedSelectionSets = () => 
+  MemFS.fs.readFileSync('./graffle/modules/selection-sets.ts', 'utf8')
+
+beforeEach(async () => {
+  try {
+    await fs.rmdir(process.cwd(), { recursive: true })
+  } catch {}
+  await fs.mkdir(process.cwd(), { recursive: true })
+})
+
+describe('Issue #1353 - Custom root type names', () => {
+  test('uses dynamic root type names instead of hardcoded Query/Mutation', async () => {
+    // Schema with custom root type names that would break with hardcoded references
+    const schema = `
+      schema {
+        query: QueryRoot
+        mutation: MutationRoot
+      }
+
+      type QueryRoot {
+        getString: String
+      }
+
+      type MutationRoot {
+        setString(value: String!): String
+      }
+    `
+
+    await generate({ fs, schema: { type: 'sdl', sdl: schema } })
+    const selectionSets = readGeneratedSelectionSets()
+
+    // Find the $Document interface
+    const documentMatch = selectionSets.match(/export interface \$Document[^}]+\}/s)
+    expect(documentMatch).toBeTruthy()
+    const documentInterface = documentMatch![0]
+
+    // Should use actual root type names from schema, not hardcoded "Query"/"Mutation"
+    expect(documentInterface).toContain('QueryRoot<_$Scalars>')
+    expect(documentInterface).toContain('MutationRoot<_$Scalars>')
+    
+    // Should NOT contain hardcoded type names
+    expect(documentInterface).not.toContain('Query<_$Scalars>')
+    expect(documentInterface).not.toContain('Mutation<_$Scalars>')
+  })
+
+  test('works with standard Query/Mutation names', async () => {
+    // Standard schema should still work
+    const schema = `
+      type Query {
+        getString: String
+      }
+
+      type Mutation {
+        setString(value: String!): String
+      }
+    `
+
+    await generate({ fs, schema: { type: 'sdl', sdl: schema } })
+    const selectionSets = readGeneratedSelectionSets()
+
+    // Find the $Document interface
+    const documentMatch = selectionSets.match(/export interface \$Document[^}]+\}/s)
+    expect(documentMatch).toBeTruthy()
+    const documentInterface = documentMatch![0]
+
+    // Should use standard names
+    expect(documentInterface).toContain('Query<_$Scalars>')
+    expect(documentInterface).toContain('Mutation<_$Scalars>')
+  })
+
+  test('handles query-only schema', async () => {
+    const schema = `
+      schema {
+        query: CustomQuery
+      }
+
+      type CustomQuery {
+        getString: String
+      }
+    `
+
+    await generate({ fs, schema: { type: 'sdl', sdl: schema } })
+    const selectionSets = readGeneratedSelectionSets()
+
+    const documentMatch = selectionSets.match(/export interface \$Document[^}]+\}/s)
+    expect(documentMatch).toBeTruthy()
+    const documentInterface = documentMatch![0]
+
+    // Should have query but no mutation
+    expect(documentInterface).toContain('query?: Record<string, CustomQuery<_$Scalars>>')
+    expect(documentInterface).not.toContain('mutation?:')
+  })
+})

--- a/src/generator/generators/SelectionSets.ts
+++ b/src/generator/generators/SelectionSets.ts
@@ -46,8 +46,8 @@ export const ModuleGeneratorSelectionSets = createModuleGenerator(
       parameters: $ScalarsTypeParameter,
       // dprint-ignore
       block: `
-        ${config.schema.kindMap.index.Root.query ? `query?: Record<string, Query<${i._$Scalars}>>` : ``}
-        ${config.schema.kindMap.index.Root.mutation ? `mutation?: Record<string, Mutation<${i._$Scalars}>>` : ``}
+        ${config.schema.kindMap.index.Root.query ? `query?: Record<string, ${renderName(config.schema.kindMap.index.Root.query)}<${i._$Scalars}>>` : ``}
+        ${config.schema.kindMap.index.Root.mutation ? `mutation?: Record<string, ${renderName(config.schema.kindMap.index.Root.mutation)}<${i._$Scalars}>>` : ``}
       `,
     }))
     code``


### PR DESCRIPTION
## Summary
Fix custom root type names in SelectionSets generator by using dynamic type references instead of hardcoded "Query" and "Mutation".

## Problem
When using GraphQL schemas with custom root type names (e.g., `QueryRoot` instead of `Query`), the SelectionSets generator was hardcoding `Query` and `Mutation` type names in the `$Document` interface, causing TypeScript compilation errors.

Example problematic schema:
```graphql
schema {
  query: QueryRoot
  mutation: MutationRoot  
}

type QueryRoot { getString: String }
type MutationRoot { setString(value: String\!): String }
```

## Root Cause
In `src/generator/generators/SelectionSets.ts` lines 49-50:
```typescript
// Before (hardcoded type names)
query?: Record<string, Query<${i._$Scalars}>>
mutation?: Record<string, Mutation<${i._$Scalars}>>
```

## Solution
Replace hardcoded type names with dynamic references to actual root type names:
```typescript
// After (dynamic type names)  
query?: Record<string, ${renderName(config.schema.kindMap.index.Root.query)}<${i._$Scalars}>>
mutation?: Record<string, ${renderName(config.schema.kindMap.index.Root.mutation)}<${i._$Scalars}>>
```

## Test Case
Added `src/generator/generators/SelectionSets.test.ts` with test cases that:
- ❌ **FAIL before the fix** (with hardcoded Query/Mutation)
- ✅ **PASS after the fix** (with dynamic type references)

Test scenarios:
- Custom root type names (`QueryRoot`, `MutationRoot`) 
- Standard root type names (`Query`, `Mutation`)
- Query-only schemas

## Generated Output
With the fix, custom root type schemas now generate correct TypeScript:
```typescript
export interface $Document<...> {
  query?: Record<string, QueryRoot<_$Scalars>>;
  mutation?: Record<string, MutationRoot<_$Scalars>>;
}
```

## Scope
This is a **minimal, targeted fix** that only changes what's necessary to resolve the reported issue. No other generators were modified to avoid introducing unnecessary complexity or potential regressions.

Fixes #1353

🤖 Generated with [Claude Code](https://claude.ai/code)