### PR TITLE
fix(generator): use named exports for custom scalars to avoid TypeScript conflict

### DIFF
--- a/src/generator/generator/__snapshots__/generate.test.ts.snap
+++ b/src/generator/generator/__snapshots__/generate.test.ts.snap
@@ -3,8 +3,7 @@
 exports[`custom scalars module results in client prefilling those custom scalars 1`] = `
 "import type * as $$Utilities from "graffle/utilities-for-generated";
 import * as CustomScalars from "../../scalars.js";
-
-export * from "../../scalars.js";
+export { Date } from "../../scalars.js";
 //
 //
 //

--- a/src/generator/generators/Scalar.test.ts
+++ b/src/generator/generators/Scalar.test.ts
@@ -50,6 +50,53 @@ beforeEach(async () => {
   await fs.mkdir(process.cwd(), { recursive: true })
 })
 
+describe('Issue #1370 - TypeScript export conflict with custom scalars', () => {
+  test('custom scalars should be available as both types and values', async () => {
+    const customScalarsBigIntDateTime = `
+      import { Graffle } from 'graffle'
+
+      export const BigInt = Graffle.Scalars.create('BigInt', {
+        decode: (value) => globalThis.BigInt(value),
+        encode: (value) => String(value),
+      })
+
+      export const DateTime = Graffle.Scalars.create('DateTime', {
+        decode: (value) => new Date(value),
+        encode: (value) => value.toISOString(),
+      })
+    `
+
+    const schemaWithCustomScalars = `
+      scalar BigInt
+      scalar DateTime
+
+      type Query {
+        getBigInt: BigInt
+        getDateTime: DateTime
+      }
+    `
+
+    await fs.writeFile('./scalars.ts', customScalarsBigIntDateTime)
+    await generate({ fs, schema: { type: 'sdl', sdl: schemaWithCustomScalars } })
+    const { scalar, sddm } = readGeneratedFiles()
+
+    // The scalar module should not use wildcard export for custom scalars
+    // as it shadows the value exports when followed by type exports
+    expect(scalar).not.toContain('export * from "../../scalars.js"')
+
+    // Should use explicit named exports for custom scalars
+    expect(scalar).toContain('export { BigInt, DateTime } from "../../scalars.js"')
+
+    // Type exports should coexist with value exports
+    expect(scalar).toContain('export type BigInt = typeof CustomScalars.BigInt')
+    expect(scalar).toContain('export type DateTime = typeof CustomScalars.DateTime')
+
+    // SDDM should be able to reference scalars as values
+    expect(sddm).toContain('const BigInt = $$Scalar.BigInt')
+    expect(sddm).toContain('const DateTime = $$Scalar.DateTime')
+  })
+})
+
 describe('Issue #1354 - TypeScript reserved keywords', () => {
   test('escapes reserved keywords in codecless scalars', async () => {
     await generate({ fs, schema: { type: 'sdl', sdl: schemas.withReservedScalars } })

--- a/src/generator/generators/Scalar.ts
+++ b/src/generator/generators/Scalar.ts
@@ -25,9 +25,17 @@ export const ModuleGeneratorScalar = createModuleGenerator(
     if (Grafaid.Schema.KindMap.hasCustomScalars(config.schema.kindMap) && config.options.customScalars) {
       code`
         import * as ${$.CustomScalars} from '${config.paths.imports.scalars}'
-
-        export * from '${config.paths.imports.scalars}'
       `
+
+      // Use explicit named exports for custom scalars to avoid TypeScript export conflict
+      // where type exports shadow value exports
+      const scalarNames = config.schema.kindMap.list.ScalarCustom.map(scalar => scalar.name).join(',\n  ')
+      code`
+        export {
+          ${scalarNames}
+        } from '${config.paths.imports.scalars}'
+      `
+
       for (const scalar of config.schema.kindMap.list.ScalarCustom) {
         code(typeTitle2(`custom scalar type`)(scalar))
         code``


### PR DESCRIPTION
## Summary

This PR fixes issue #1370 where custom scalars in the generated code cause TypeScript compilation errors due to export conflicts.

## Problem

When using custom scalars with Graffle, the generated `scalar.ts` module creates a TypeScript compilation error. The issue occurs because:

1. The module uses `export * from '../../scalars.js'` to re-export custom scalar values
2. This is followed by `export type ScalarName = typeof ...` declarations
3. TypeScript treats the scalars as type-only exports, making them unavailable as runtime values
4. This causes compilation errors when other generated modules try to use the scalars as values

## Solution

Changed the generator to use **explicit named exports** for custom scalars instead of wildcard exports:

**Before:**
```typescript
export * from '../../scalars.js'
export type BigInt = typeof CustomScalars.BigInt  // This shadows the value export!
```

**After:**
```typescript
export {
  BigInt,
  DateTime
} from '../../scalars.js'
export type BigInt = typeof CustomScalars.BigInt  // Now coexists with value export
```

## Changes

1. Modified `src/generator/generators/Scalar.ts` to use named exports for custom scalars
2. Added test case to verify custom scalars are available as both types and values
3. Updated existing snapshot to reflect the new export pattern

## Test Plan

- [x] Added new test case that reproduces the issue and verifies the fix
- [x] All existing generator tests pass
- [x] TypeScript compilation succeeds (`pnpm check:types`)
- [x] All generator tests pass (`pnpm test src/generator`)

Fixes #1370