### PR TITLE
fix(generator): respect defaultSchemaUrl false setting

### DIFF
--- a/src/generator/config/config.test.ts
+++ b/src/generator/config/config.test.ts
@@ -84,3 +84,72 @@ test(`configured schema introspection options are passed to introspection`, asyn
   expect(c1.schema.sdl).toMatch(/A date-time string at UTC/)
   expect(c2.schema.sdl).not.toMatch(/A date-time string at UTC/)
 })
+
+describe(`defaultSchemaUrl`, () => {
+  test(`when false, should not set URL even for URL schema`, async ({ pokemonService }) => {
+    const config = await createConfig({
+      schema: {
+        type: `url`,
+        url: pokemonService.url,
+      },
+      defaultSchemaUrl: false,
+    })
+    expect(config.options.defaultSchemaUrl).toBeNull()
+  })
+
+  test(`when true, should set URL from URL schema`, async ({ pokemonService }) => {
+    const config = await createConfig({
+      schema: {
+        type: `url`,
+        url: pokemonService.url,
+      },
+      defaultSchemaUrl: true,
+    })
+    expect(config.options.defaultSchemaUrl).toEqual(pokemonService.url)
+  })
+
+  test(`when omitted, should default to true and set URL from URL schema`, async ({ pokemonService }) => {
+    const config = await createConfig({
+      schema: {
+        type: `url`,
+        url: pokemonService.url,
+      },
+    })
+    expect(config.options.defaultSchemaUrl).toEqual(pokemonService.url)
+  })
+
+  test(`when explicit URL provided, should use that URL`, async ({ pokemonService }) => {
+    const customUrl = new URL(`https://custom.example.com/graphql`)
+    const config = await createConfig({
+      schema: {
+        type: `url`,
+        url: pokemonService.url,
+      },
+      defaultSchemaUrl: customUrl,
+    })
+    expect(config.options.defaultSchemaUrl).toEqual(customUrl)
+  })
+
+  test(`when false with SDL schema, should be null`, async () => {
+    const config = await createConfig({
+      schema,
+      defaultSchemaUrl: false,
+    })
+    expect(config.options.defaultSchemaUrl).toBeNull()
+  })
+
+  test(`when true with SDL schema, should be null`, async () => {
+    const config = await createConfig({
+      schema,
+      defaultSchemaUrl: true,
+    })
+    expect(config.options.defaultSchemaUrl).toBeNull()
+  })
+
+  test(`when omitted with SDL schema, should be null`, async () => {
+    const config = await createConfig({
+      schema,
+    })
+    expect(config.options.defaultSchemaUrl).toBeNull()
+  })
+})

--- a/src/generator/config/config.ts
+++ b/src/generator/config/config.ts
@@ -139,13 +139,15 @@ export const createConfig = async (configInit: ConfigInit): Promise<Config> => {
 
   // dprint-ignore
   const defaultSchemaUrl =
-    typeof configInit.defaultSchemaUrl === `boolean`
-      ? configInit.schema instanceof Grafaid.Schema.Schema
-        ? null
-        : configInit.schema.type === `url`
-          ? configInit.schema.url
-          : null
-      : configInit.defaultSchemaUrl ?? null
+    configInit.defaultSchemaUrl === false
+      ? null
+      : typeof configInit.defaultSchemaUrl === `boolean` || configInit.defaultSchemaUrl === undefined
+        ? configInit.schema instanceof Grafaid.Schema.Schema
+          ? null
+          : configInit.schema.type === `url`
+            ? configInit.schema.url
+            : null
+        : configInit.defaultSchemaUrl
 
   // --- Formatting ---
 


### PR DESCRIPTION
## Summary

Fixes #1321 

The `defaultSchemaUrl` option in the Graffle Generator was not working correctly when set to `false` or omitted.

## Problem

- When `defaultSchemaUrl: false`, it still set the URL (behaved like `true`)
- When `defaultSchemaUrl` was omitted, it didn't set the URL (should default to `true`)

## Solution

Updated the logic in `config.ts` to properly handle all cases:
- `defaultSchemaUrl: false` → Never sets URL
- `defaultSchemaUrl: true` or omitted → Sets URL from URL-based schema  
- `defaultSchemaUrl: <explicit URL>` → Uses that URL

## Test plan

Added comprehensive test coverage for all `defaultSchemaUrl` scenarios in `config.test.ts`:
- ✅ When false with URL schema → null
- ✅ When true with URL schema → uses schema URL
- ✅ When omitted with URL schema → uses schema URL (default behavior)
- ✅ When explicit URL provided → uses that URL
- ✅ When used with SDL/instance schemas → always null