### PR TITLE
fix: parse GraphQL errors from response body on HTTP 4xx/5xx status codes

### DIFF
--- a/src/legacy/helpers/runRequest.ts
+++ b/src/legacy/helpers/runRequest.ts
@@ -71,16 +71,9 @@ export const runRequest = async (input: Input): Promise<ClientError | GraphQLCli
   const fetcher = createFetcher(config.method)
   const fetchResponse = await fetcher(config)
 
-  if (!fetchResponse.ok) {
-    return new ClientError(
-      { status: fetchResponse.status, headers: fetchResponse.headers },
-      {
-        query: input.request._tag === `Single` ? input.request.document.expression : input.request.query,
-        variables: input.request.variables,
-      },
-    )
-  }
-
+  // Parse response body FIRST, regardless of HTTP status
+  // This allows GraphQL errors to be extracted even when HTTP status is 4xx/5xx
+  // Fixes regression from v6 to v7 where 4xx responses lost GraphQL error details
   const result = await parseResultFromResponse(
     fetchResponse,
     input.fetchOptions.jsonSerializer ?? defaultJsonSerializer,
@@ -91,6 +84,21 @@ export const runRequest = async (input: Input): Promise<ClientError | GraphQLCli
   const clientResponseBase = {
     status: fetchResponse.status,
     headers: fetchResponse.headers,
+  }
+
+  // Handle non-2xx HTTP status codes WITH parsed GraphQL response
+  if (!fetchResponse.ok) {
+    const clientResponse = result._tag === `Batch`
+      ? { ...result.executionResults, ...clientResponseBase }
+      : {
+        ...result.executionResult,
+        ...clientResponseBase,
+      }
+    // @ts-expect-error todo
+    return new ClientError(clientResponse, {
+      query: input.request._tag === `Single` ? input.request.document.expression : input.request.query,
+      variables: input.request.variables,
+    })
   }
 
   if (isRequestResultHaveErrors(result) && config.fetchOptions.errorPolicy === `none`) {

--- a/tests/legacy/http-status-with-errors.test.ts
+++ b/tests/legacy/http-status-with-errors.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'vitest'
+import { ClientError } from '../../src/entrypoints/main.js'
+import { GraphQLClient } from '../../src/entrypoints/main.js'
+import { setupMockServer } from './__helpers.js'
+
+const ctx = setupMockServer()
+
+describe(`HTTP 4xx/5xx status codes with GraphQL response body`, () => {
+  test(`422 status with GraphQL errors in body - errors should be accessible`, async () => {
+    const data = { user: null }
+    const graphqlErrors = [
+      {
+        message: `User not authenticated`,
+        extensions: { code: `UNAUTHENTICATED` },
+      },
+    ]
+
+    // Setup mock to return 422 with GraphQL error response
+    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+    ctx.server.use(`*`, function mock(req, res) {
+      res.status(422).json({
+        data,
+        errors: graphqlErrors,
+      })
+    })
+
+    const client = new GraphQLClient(ctx.url)
+
+    try {
+      await client.request(`{ user { id } }`)
+      expect.fail(`Expected ClientError to be thrown`)
+    } catch (error) {
+      expect(error).toBeInstanceOf(ClientError)
+      const clientError = error as ClientError
+      expect(clientError.response.status).toBe(422)
+      expect(clientError.response.errors).toEqual(graphqlErrors)
+      expect(clientError.response.data).toEqual(data)
+    }
+  })
+
+  test(`500 status with GraphQL errors in body - errors should be accessible`, async () => {
+    const graphqlErrors = [
+      {
+        message: `Internal server error`,
+        extensions: { code: `INTERNAL_SERVER_ERROR` },
+      },
+    ]
+
+    // Setup mock to return 500 with GraphQL error response
+    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+    ctx.server.use(`*`, function mock(req, res) {
+      res.status(500).json({
+        errors: graphqlErrors,
+      })
+    })
+
+    const client = new GraphQLClient(ctx.url)
+
+    try {
+      await client.request(`{ user { id } }`)
+      expect.fail(`Expected ClientError to be thrown`)
+    } catch (error) {
+      expect(error).toBeInstanceOf(ClientError)
+      const clientError = error as ClientError
+      expect(clientError.response.status).toBe(500)
+      expect(clientError.response.errors).toEqual(graphqlErrors)
+    }
+  })
+
+  test(`404 status with GraphQL errors in body - errors should be accessible`, async () => {
+    const graphqlErrors = [
+      {
+        message: `Resource not found`,
+      },
+    ]
+
+    // Setup mock to return 404 with GraphQL error response
+    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+    ctx.server.use(`*`, function mock(req, res) {
+      res.status(404).json({
+        errors: graphqlErrors,
+      })
+    })
+
+    const client = new GraphQLClient(ctx.url)
+
+    try {
+      await client.request(`{ resource { id } }`)
+      expect.fail(`Expected ClientError to be thrown`)
+    } catch (error) {
+      expect(error).toBeInstanceOf(ClientError)
+      const clientError = error as ClientError
+      expect(clientError.response.status).toBe(404)
+      expect(clientError.response.errors).toEqual(graphqlErrors)
+    }
+  })
+
+  test(`403 status with both data and errors - both should be accessible`, async () => {
+    const data = { publicData: `visible` }
+    const graphqlErrors = [
+      {
+        message: `Not authorized to access private fields`,
+        path: [`user`, `privateField`],
+      },
+    ]
+
+    // Setup mock to return 403 with partial data and errors
+    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+    ctx.server.use(`*`, function mock(req, res) {
+      res.status(403).json({
+        data,
+        errors: graphqlErrors,
+      })
+    })
+
+    const client = new GraphQLClient(ctx.url)
+
+    try {
+      await client.request(`{ publicData user { privateField } }`)
+      expect.fail(`Expected ClientError to be thrown`)
+    } catch (error) {
+      expect(error).toBeInstanceOf(ClientError)
+      const clientError = error as ClientError
+      expect(clientError.response.status).toBe(403)
+      expect(clientError.response.errors).toEqual(graphqlErrors)
+      expect(clientError.response.data).toEqual(data)
+    }
+  })
+
+  test(`400 status with validation errors - errors should be accessible`, async () => {
+    const graphqlErrors = [
+      {
+        message: `Variable "$id" of required type "ID!" was not provided.`,
+        extensions: { code: `BAD_USER_INPUT` },
+      },
+    ]
+
+    // Setup mock to return 400 with validation errors
+    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+    ctx.server.use(`*`, function mock(req, res) {
+      res.status(400).json({
+        errors: graphqlErrors,
+      })
+    })
+
+    const client = new GraphQLClient(ctx.url)
+
+    try {
+      await client.request(`query($id: ID!) { user(id: $id) { id } }`)
+      expect.fail(`Expected ClientError to be thrown`)
+    } catch (error) {
+      expect(error).toBeInstanceOf(ClientError)
+      const clientError = error as ClientError
+      expect(clientError.response.status).toBe(400)
+      expect(clientError.response.errors).toEqual(graphqlErrors)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Fixes regression from v6 to v7 where HTTP 4xx/5xx responses would throw `ClientError` without including the GraphQL errors from the response body.

### Changes
- Parse response body **before** checking HTTP status in `runRequest.ts:74-102`
- Include parsed GraphQL response (errors + data) in `ClientError` when HTTP status is non-2xx
- Add comprehensive test suite covering various HTTP error status codes (422, 500, 404, 403, 400)

### Rationale

In v6, when a server returned a 4xx/5xx HTTP status with a valid GraphQL response body containing errors, users could access those errors via `error.response.errors`. This was a common pattern for handling authentication errors (422), server errors (500), etc.

The v7 implementation in `runRequest.ts` checked `fetchResponse.ok` **before** parsing the response body, which meant the GraphQL errors were never extracted and included in the `ClientError`. This broke user code that relied on accessing error details.

### Solution

The fix moves the `parseResultFromResponse()` call to happen **before** the HTTP status check. This ensures:
1. Response body is always parsed if it contains valid GraphQL response
2. `ClientError` includes both HTTP metadata (status, headers) AND GraphQL response data (errors, data)
3. Behavior matches v6 where errors are accessible regardless of HTTP status

### Test Plan
- ✅ All existing tests pass (75 tests)
- ✅ New test suite with 5 test cases covering:
  - 422 status with GraphQL errors + data
  - 500 status with GraphQL errors only  
  - 404 status with GraphQL errors
  - 403 status with partial data + errors
  - 400 status with validation errors

Closes #1281