### PR TITLE
Fix: parse GraphQL errors from 4xx/5xx responses (#1281)

### DIFF
--- a/tests/legacy/http-status-with-errors.test.ts
+++ b/tests/legacy/http-status-with-errors.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'vitest'
+import { ClientError } from '../../src/entrypoints/main.js'
+import { GraphQLClient } from '../../src/entrypoints/main.js'
+import { setupMockServer } from './__helpers.js'
+
+const ctx = setupMockServer()
+
+describe(`HTTP 4xx/5xx status codes with GraphQL response body`, () => {
+  test(`422 status with GraphQL errors in body - errors should be accessible`, async () => {
+    const data = { user: null }
+    const graphqlErrors = [
+      {
+        message: `User not authenticated`,
+        extensions: { code: `UNAUTHENTICATED` },
+      },
+    ]
+
+    // Setup mock to return 422 with GraphQL error response
+    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+    ctx.server.use(`*`, function mock(req, res) {
+      res.status(422).json({
+        data,
+        errors: graphqlErrors,
+      })
+    })
+
+    const client = new GraphQLClient(ctx.url)
+
+    try {
+      await client.request(`{ user { id } }`)
+      expect.fail(`Expected ClientError to be thrown`)
+    } catch (error) {
+      expect(error).toBeInstanceOf(ClientError)
+      const clientError = error as ClientError
+      expect(clientError.response.status).toBe(422)
+      expect(clientError.response.errors).toEqual(graphqlErrors)
+      expect(clientError.response.data).toEqual(data)
+    }
+  })
+
+  test(`500 status with GraphQL errors in body - errors should be accessible`, async () => {
+    const graphqlErrors = [
+      {
+        message: `Internal server error`,
+        extensions: { code: `INTERNAL_SERVER_ERROR` },
+      },
+    ]
+
+    // Setup mock to return 500 with GraphQL error response
+    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+    ctx.server.use(`*`, function mock(req, res) {
+      res.status(500).json({
+        errors: graphqlErrors,
+      })
+    })
+
+    const client = new GraphQLClient(ctx.url)
+
+    try {
+      await client.request(`{ user { id } }`)
+      expect.fail(`Expected ClientError to be thrown`)
+    } catch (error) {
+      expect(error).toBeInstanceOf(ClientError)
+      const clientError = error as ClientError
+      expect(clientError.response.status).toBe(500)
+      expect(clientError.response.errors).toEqual(graphqlErrors)
+    }
+  })
+
+  test(`404 status with GraphQL errors in body - errors should be accessible`, async () => {
+    const graphqlErrors = [
+      {
+        message: `Resource not found`,
+      },
+    ]
+
+    // Setup mock to return 404 with GraphQL error response
+    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+    ctx.server.use(`*`, function mock(req, res) {
+      res.status(404).json({
+        errors: graphqlErrors,
+      })
+    })
+
+    const client = new GraphQLClient(ctx.url)
+
+    try {
+      await client.request(`{ resource { id } }`)
+      expect.fail(`Expected ClientError to be thrown`)
+    } catch (error) {
+      expect(error).toBeInstanceOf(ClientError)
+      const clientError = error as ClientError
+      expect(clientError.response.status).toBe(404)
+      expect(clientError.response.errors).toEqual(graphqlErrors)
+    }
+  })
+
+  test(`403 status with both data and errors - both should be accessible`, async () => {
+    const data = { publicData: `visible` }
+    const graphqlErrors = [
+      {
+        message: `Not authorized to access private fields`,
+        path: [`user`, `privateField`],
+      },
+    ]
+
+    // Setup mock to return 403 with partial data and errors
+    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+    ctx.server.use(`*`, function mock(req, res) {
+      res.status(403).json({
+        data,
+        errors: graphqlErrors,
+      })
+    })
+
+    const client = new GraphQLClient(ctx.url)
+
+    try {
+      await client.request(`{ publicData user { privateField } }`)
+      expect.fail(`Expected ClientError to be thrown`)
+    } catch (error) {
+      expect(error).toBeInstanceOf(ClientError)
+      const clientError = error as ClientError
+      expect(clientError.response.status).toBe(403)
+      expect(clientError.response.errors).toEqual(graphqlErrors)
+      expect(clientError.response.data).toEqual(data)
+    }
+  })
+
+  test(`400 status with validation errors - errors should be accessible`, async () => {
+    const graphqlErrors = [
+      {
+        message: `Variable "$id" of required type "ID!" was not provided.`,
+        extensions: { code: `BAD_USER_INPUT` },
+      },
+    ]
+
+    // Setup mock to return 400 with validation errors
+    // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
+    ctx.server.use(`*`, function mock(req, res) {
+      res.status(400).json({
+        errors: graphqlErrors,
+      })
+    })
+
+    const client = new GraphQLClient(ctx.url)
+
+    try {
+      await client.request(`query($id: ID!) { user(id: $id) { id } }`)
+      expect.fail(`Expected ClientError to be thrown`)
+    } catch (error) {
+      expect(error).toBeInstanceOf(ClientError)
+      const clientError = error as ClientError
+      expect(clientError.response.status).toBe(400)
+      expect(clientError.response.errors).toEqual(graphqlErrors)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Implements a minimal, backwards-compatible fix for #1281 where GraphQL errors were inaccessible in non-2xx HTTP responses.

## Problem

**Issue #1281:** Some GraphQL endpoints use HTTP status codes semantically (e.g., 422 for validation errors, 401 for auth) but still return valid GraphQL response bodies with `errors` and `data` fields.

**Before this fix:**
```typescript
try {
  await client.request('{ user { id } }')
} catch (error) {
  error.response.status === 422  // ✓ accessible
  error.response.errors === undefined  // ✗ NOT accessible (broken!)
}
```

**After this fix:**
```typescript
try {
  await client.request('{ user { id } }')
} catch (error) {
  error.response.status === 422  // ✓ accessible
  error.response.errors === [...]  // ✓ accessible (fixed!)
}
```

## Solution

Parse response body FIRST (before checking HTTP status), then:
- **Non-2xx + parse succeeds:** Return `ClientError` WITH GraphQL errors/data (fixes #1281)
- **Non-2xx + parse fails:** Return `ClientError` WITHOUT GraphQL data (prevents #1461/#1462 regression)
- **2xx + parse fails:** Throw `Error` (existing behavior)

### Code Changes

**File:** `src/legacy/helpers/runRequest.ts`

Changed order of operations:
1. ~~Check HTTP status first~~ → Parse body first
2. ~~Parse body only for 2xx~~ → Parse for all status codes
3. ~~Return ClientError without body~~ → Include parsed errors/data when available

**Minimal changeset:** Only 1 file modified + 1 test file added

## Backwards Compatibility

✅ **No breaking changes:**
- All non-2xx responses still return `ClientError` (same type)
- `.response.status` always accessible (same API)
- 2xx with parse errors still throw `Error` (same behavior)

✅ **Fixes regressions:**
- #1281 - Can now access `.response.errors` for 4xx/5xx
- #1461/#1462 - Still returns `ClientError` for auth failures (not generic `Error`)

## Test Coverage

**New test file:** `tests/legacy/http-status-with-errors.test.ts`

Comprehensive test cases:
- ✅ 422 with GraphQL errors and data
- ✅ 500 with GraphQL errors
- ✅ 404 with GraphQL errors
- ✅ 403 with partial data and errors
- ✅ 400 with validation errors

**Test results:**
- 75 tests passing (+ 1 skipped)
- TypeScript compiles with no errors

## Related Issues

Fixes #1281
Prevents regression of #1461 and #1462

## Supersedes

Supersedes #1464 (auto-closed when base branch was deleted after #1463 merge)