### PR TITLE
fix: update @wollybeard/kit to v0.102.1 for browser compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@0no-co/graphql.web": "1.2.0",
     "@graphql-typed-document-node/core": "^3.2.0",
     "@molt/command": "^0.9.0",
-    "@wollybeard/kit": "^0.101.1",
+    "@wollybeard/kit": "^0.102.1",
     "es-toolkit": "^1.41.0",
     "type-fest": "^5.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^0.9.0
         version: 0.9.0
       '@wollybeard/kit':
-        specifier: ^0.101.1
-        version: 0.101.1(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)
+        specifier: ^0.102.1
+        version: 0.102.1(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)
       es-toolkit:
         specifier: ^1.41.0
         version: 1.41.0
@@ -2106,8 +2106,8 @@ packages:
     resolution: {integrity: sha512-Otmxo+0mp8az3B48pLI1I4msNOXPIoP7TLm6h5wOEQmynqHt8oP9nR6NJUeJk6iI5OtFpQtkbJFwfGkmplvc3Q==}
     engines: {node: '>=18.0.0'}
 
-  '@wollybeard/kit@0.101.1':
-    resolution: {integrity: sha512-JwtrN6ipuGDLmuMQfGm6dgwoVFoCsmXtZvgULaMcf5X/B4v8IHdCSyp3dyOAXWmeQLjVcwD99+SLI2PiuCbO/g==}
+  '@wollybeard/kit@0.102.1':
+    resolution: {integrity: sha512-rxDvb8N1GlFK/VOGT/HW8b+toDIb5MMRXzuQ3hFTFAFmLCT0yj00gHuQW2JnSrb2UUKwgIp9CyKuI768Drv/ZA==}
     peerDependencies:
       '@effect/platform': '>=0.90.0 <1.0.0'
       effect: ^3.17.0
@@ -6547,7 +6547,7 @@ snapshots:
       '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
 
-  '@wollybeard/kit@0.101.1(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)':
+  '@wollybeard/kit@0.102.1(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)':
     dependencies:
       '@effect/platform': 0.92.1(effect@3.18.4)
       '@microsoft/tsdoc': 0.15.1


### PR DESCRIPTION
## Summary

Updates `@wollybeard/kit` from v0.101.1 to v0.102.1, which includes a fix to make ConfigManager browser-compatible.

## Problem

Next.js builds were failing with the following error when importing Graffle in client-side code:

```
Module not found: Can't resolve 'util/types'
```

This occurred because `@wollybeard/kit`'s ConfigManager was importing `util/types`, a Node.js-only core module not available in browser environments.

## Solution

The updated version of `@wollybeard/kit` (v0.102.1) replaces the Node.js-specific `util/types` import with a browser-compatible alternative that uses `instanceof Date` instead.

**Upstream fix:** jasonkuhrt/kit#81

## Changes

- Updated `@wollybeard/kit` dependency from `^0.101.1` to `^0.102.1`
- Updated `pnpm-lock.yaml`

## Testing

- ✅ `pnpm install` completed successfully
- ✅ `pnpm build` completed successfully without errors

## Closes

Closes #1460