### PR TITLE
refactor: migrate CLI from Zod to Effect Schema via Oak

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,8 +110,7 @@
   "dependencies": {
     "@0no-co/graphql.web": "1.2.0",
     "@graphql-typed-document-node/core": "^3.2.0",
-    "@molt/command": "^0.9.0",
-    "@wollybeard/kit": "^0.103.1",
+    "@wollybeard/kit": "^0.104.0",
     "es-toolkit": "^1.41.0",
     "type-fest": "^5.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,12 +14,9 @@ importers:
       '@graphql-typed-document-node/core':
         specifier: ^3.2.0
         version: 3.2.0(graphql@16.11.0)
-      '@molt/command':
-        specifier: ^0.9.0
-        version: 0.9.0
       '@wollybeard/kit':
-        specifier: ^0.103.1
-        version: 0.103.1(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)
+        specifier: ^0.104.0
+        version: 0.104.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)(zod@3.24.3)
       es-toolkit:
         specifier: ^1.41.0
         version: 1.41.0
@@ -1171,12 +1168,6 @@ packages:
   '@microsoft/tsdoc@0.15.1':
     resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
 
-  '@molt/command@0.9.0':
-    resolution: {integrity: sha512-1JI8dAlpqlZoXyKWVQggX7geFNPxBpocHIXQCsnxDjKy+3WX4SGyZVJXuLlqRRrX7FmQCuuMAfx642ovXmPA9g==}
-
-  '@molt/types@0.2.0':
-    resolution: {integrity: sha512-p6ChnEZDGjg9PYPec9BK6Yp5/DdSrYQvXTBAtgrnqX6N36cZy37ql1c8Tc5LclfIYBNG7EZp8NBcRTYJwyi84g==}
-
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     resolution: {integrity: sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==}
     cpu: [arm64]
@@ -1939,49 +1930,49 @@ packages:
     resolution: {integrity: sha512-SvUHQgZJg0d7Mc1yec+5lF2DFiwbEgikCvdqXdxWAxjSdXhj7d6vNUH3MitrZCJPiUpdvOejS4DVHanLfcwI9g==}
     engines: {node: '>=22'}
 
-  '@vltpkg/dep-id@1.0.0-rc.9':
-    resolution: {integrity: sha512-oJqGX7U4LCD1B6rdCQB5RVWhFPlRtD4/obP/wnD2GYYHUEuCIwP22SscL2ONc1b8M5e3P84ZobSxNBF15BzNoQ==}
-    engines: {node: '>=22'}
+  '@vltpkg/dep-id@1.0.0-rc.10':
+    resolution: {integrity: sha512-TgaaBLaKZnJipOvh+mhzja3mRWhg9LbLA+qtt7JjxIOVfzaxhtHsJPrwaibslY7uqmcJQ+rn0XluT60sROb+mw==}
+    engines: {node: '>=22.9.0'}
 
   '@vltpkg/error-cause@0.0.0-30':
     resolution: {integrity: sha512-j+rjUo0m1C81HdoW7qLgQFHGedg4YypzAYEdrUT04f4DGLZB3Qf9OS1Wd26IzICjMxB8OSAxFqKHikst3KR4wA==}
     engines: {node: '>=22'}
 
-  '@vltpkg/error-cause@1.0.0-rc.9':
-    resolution: {integrity: sha512-zyV7JCKt33RpC9NsXnJwFG1OxqpER8mn/HbpE9l1z6LYZKLdafepuGW4FrG0558Ms5V04lOShT1IufH4l5DhkA==}
-    engines: {node: '>=22'}
+  '@vltpkg/error-cause@1.0.0-rc.10':
+    resolution: {integrity: sha512-ckmScIrC870Y1MXoGZmCVJ7K87WnJqFEHD5OrGcIcYpPezauzTh/ZqNPIwvqjgJ9t0oby+cxhDaXUrVBdRY3Cw==}
+    engines: {node: '>=22.9.0'}
 
   '@vltpkg/fast-split@0.0.0-30':
     resolution: {integrity: sha512-UhCch9sy30lyR5Ry8knwIi46MGCr8fMQ/Z3TG2dBxH2kkTWKkOPc0s8wa9uz8y0BkE9fqku2gVkTAnz1yCeROg==}
     engines: {node: '>=22'}
 
-  '@vltpkg/fast-split@1.0.0-rc.9':
-    resolution: {integrity: sha512-7R//3m6jPTEiL7371tY4WuI1R2AAOqFVPi2+yMlXu7O9S8aPCdYtzHVsqQxm10WUpZ41dWLSYe4wmxHuccB59A==}
-    engines: {node: '>=22'}
+  '@vltpkg/fast-split@1.0.0-rc.10':
+    resolution: {integrity: sha512-8PvIk6+WEx46HDLiGQRTH55MR1smN/k4fk4NIcJhptG54TRkdq+LfbzuYOsJZz4ON0rvtpaxBDq6Qy7aFSo2kQ==}
+    engines: {node: '>=22.9.0'}
 
   '@vltpkg/semver@0.0.0-30':
     resolution: {integrity: sha512-GWqy5Rr5L9VeJDE6Yb0BscLehLWc1GWDAShxFFmfGBqr68Vy0DF5YSWb0NvVpfQ0r+uIxA5FK7b7bK0oJKThPw==}
     engines: {node: '>=22'}
 
-  '@vltpkg/semver@1.0.0-rc.9':
-    resolution: {integrity: sha512-gEPgcg644nnq/kwEA1hAY5ecwLEOm3hlzUGfheasQvIeR6Ix0fmZqqIG0c0gpz6h0URobGBf5s0ydoRbOcQ46A==}
-    engines: {node: '>=22'}
+  '@vltpkg/semver@1.0.0-rc.10':
+    resolution: {integrity: sha512-vAiSiprc1bRUl5+Qs2PASqJC1uxOL7Bnn+/LdOnMbbYKqb3+aST8mX5NYUQLsErxqB4+TfXCzGO2E3Qxvi4SJA==}
+    engines: {node: '>=22.9.0'}
 
   '@vltpkg/spec@0.0.0-30':
     resolution: {integrity: sha512-0eYijND+UJBNkrEpL7+Ammc6Sjk7bAOZC33PETYXkV3JGl8npoV3o4w3rigtwfZVuedfi81RmMcr0Nb2JjNaMw==}
     engines: {node: '>=22'}
 
-  '@vltpkg/spec@1.0.0-rc.9':
-    resolution: {integrity: sha512-sS92duIYQy3Yy6DhoS8/0tJqvv1NPyAOL/x3AZkpAeRNtkr5vSZ+kroV8+Da6bfZMwsscyy4YBoCJzalmfmNeA==}
-    engines: {node: '>=22'}
+  '@vltpkg/spec@1.0.0-rc.10':
+    resolution: {integrity: sha512-u7IN1hi1sDLGWfxt/xBXvvNh97I3IS2E7XLnxqjnQHI73ZgPvRvqRmg+o7zsjSvBJQ6Ih7AMacIR6pJQyV1ZAA==}
+    engines: {node: '>=22.9.0'}
 
   '@vltpkg/types@0.0.0-30':
     resolution: {integrity: sha512-gUqYAZwVQjmjbM+xnyZNHnpMyXIvDN5nIzifWY9RKJ9XEmPVJg8Nql5zMXXPbr1MekMZzBvqvCgMeoDV53dX2g==}
     engines: {node: '>=22'}
 
-  '@vltpkg/types@1.0.0-rc.9':
-    resolution: {integrity: sha512-YDnyotdPx2skWTGEgktBM9pC3jVHgIF8u1ydSOZLSF/qwoGC56N7xAhR0bg58lw0LbyxbOKQTRhdBYMzv9/Pjw==}
-    engines: {node: '>=22'}
+  '@vltpkg/types@1.0.0-rc.10':
+    resolution: {integrity: sha512-rAT+cJSqzq6jF9x2TXnw8vKi+e2Yst3JmgzUFSonnhwaF4Wld19yiQ0LPZIxnn5auJRg0qQP0izW7Lo0p/j9BQ==}
+    engines: {node: '>=22.9.0'}
 
   '@volar/language-core@2.4.23':
     resolution: {integrity: sha512-hEEd5ET/oSmBC6pi1j6NaNYRWoAiDhINbT8rmwtINugR39loROSlufGdYMF9TaKGfz+ViGs1Idi3mAhnuPcoGQ==}
@@ -2109,11 +2100,15 @@ packages:
     resolution: {integrity: sha512-Otmxo+0mp8az3B48pLI1I4msNOXPIoP7TLm6h5wOEQmynqHt8oP9nR6NJUeJk6iI5OtFpQtkbJFwfGkmplvc3Q==}
     engines: {node: '>=18.0.0'}
 
-  '@wollybeard/kit@0.103.1':
-    resolution: {integrity: sha512-lkWpIFf6h2v3xgZR93i9UXTS3hARnEu8xtN4vVrLejH6qIoE6ji15f4RhUMGHxUBdjtQasyIet9l81pODKCAzw==}
+  '@wollybeard/kit@0.104.0':
+    resolution: {integrity: sha512-4HbHecW4qv61Yd85K0+S83ycBeaJ3UtdJjXrVB98HsNxCx62BnO0nThJ2XbRSiUzopht7nVnN23TkoRWSKgk6A==}
     peerDependencies:
       '@effect/platform': '>=0.90.0 <1.0.0'
       effect: ^3.17.0
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@wollybeard/kit@0.85.3':
     resolution: {integrity: sha512-hB7gpJTJfSdI6ys2jU/ifHWeYOWoKz/yqkuvJScVSmfqr7zGZ3AlRHxmo8Q+9RYPcUh6dlIayFWcq+jUp5cZbw==}
@@ -3272,14 +3267,8 @@ packages:
   lodash-es@4.17.21:
     resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
 
-  lodash.camelcase@4.3.0:
-    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
-
   lodash.ismatch@4.4.0:
     resolution: {integrity: sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==}
-
-  lodash.snakecase@4.1.1:
-    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -3821,10 +3810,6 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
-  readline-sync@1.4.10:
-    resolution: {integrity: sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==}
-    engines: {node: '>= 0.8.0'}
-
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -4099,10 +4084,6 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
-  string-length@6.0.0:
-    resolution: {integrity: sha512-1U361pxZHEQ+FeSjzqRpV+cu2vTzYeWeafXFLykiFlv4Vc0n3njgU8HrMbyik5uwm77naWMuVG8fhEF+Ovb1Kg==}
-    engines: {node: '>=16'}
-
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -4296,10 +4277,6 @@ packages:
     resolution: {integrity: sha512-RtJURJlGRxrkJmTcZMjpr7jdYly1rfgpujJr1sBM9ch7SKVht/SjFk23IOAyvwT1NLCk+SJiMrvW4rIAUM2Wug==}
     peerDependencies:
       typescript: ^5.5.0
-
-  type-fest@4.41.0:
-    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
-    engines: {node: '>=16'}
 
   type-fest@5.1.0:
     resolution: {integrity: sha512-wQ531tuWvB6oK+pchHIu5lHe5f5wpSCqB8Kf4dWQRbOYc9HTge7JL0G4Qd44bh6QuJCccIzL3bugb8GI0MwHrg==}
@@ -5513,24 +5490,6 @@ snapshots:
 
   '@microsoft/tsdoc@0.15.1': {}
 
-  '@molt/command@0.9.0':
-    dependencies:
-      '@molt/types': 0.2.0
-      alge: 0.8.1
-      chalk: 5.6.2
-      lodash.camelcase: 4.3.0
-      lodash.snakecase: 4.1.1
-      readline-sync: 1.4.10
-      string-length: 6.0.0
-      strip-ansi: 7.1.2
-      ts-toolbelt: 9.6.0
-      type-fest: 4.41.0
-      zod: 3.24.3
-
-  '@molt/types@0.2.0':
-    dependencies:
-      ts-toolbelt: 9.6.0
-
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3':
     optional: true
 
@@ -6359,19 +6318,19 @@ snapshots:
       '@vltpkg/spec': 0.0.0-30
       '@vltpkg/types': 0.0.0-30
 
-  '@vltpkg/dep-id@1.0.0-rc.9':
+  '@vltpkg/dep-id@1.0.0-rc.10':
     dependencies:
-      '@vltpkg/error-cause': 1.0.0-rc.9
-      '@vltpkg/spec': 1.0.0-rc.9
-      '@vltpkg/types': 1.0.0-rc.9
+      '@vltpkg/error-cause': 1.0.0-rc.10
+      '@vltpkg/spec': 1.0.0-rc.10
+      '@vltpkg/types': 1.0.0-rc.10
 
   '@vltpkg/error-cause@0.0.0-30': {}
 
-  '@vltpkg/error-cause@1.0.0-rc.9': {}
+  '@vltpkg/error-cause@1.0.0-rc.10': {}
 
   '@vltpkg/fast-split@0.0.0-30': {}
 
-  '@vltpkg/fast-split@1.0.0-rc.9': {}
+  '@vltpkg/fast-split@1.0.0-rc.10': {}
 
   '@vltpkg/semver@0.0.0-30':
     dependencies:
@@ -6379,21 +6338,21 @@ snapshots:
       '@vltpkg/fast-split': 0.0.0-30
       '@vltpkg/types': 0.0.0-30
 
-  '@vltpkg/semver@1.0.0-rc.9':
+  '@vltpkg/semver@1.0.0-rc.10':
     dependencies:
-      '@vltpkg/error-cause': 1.0.0-rc.9
-      '@vltpkg/fast-split': 1.0.0-rc.9
-      '@vltpkg/types': 1.0.0-rc.9
+      '@vltpkg/error-cause': 1.0.0-rc.10
+      '@vltpkg/fast-split': 1.0.0-rc.10
+      '@vltpkg/types': 1.0.0-rc.10
 
   '@vltpkg/spec@0.0.0-30':
     dependencies:
       '@vltpkg/error-cause': 0.0.0-30
       '@vltpkg/semver': 0.0.0-30
 
-  '@vltpkg/spec@1.0.0-rc.9':
+  '@vltpkg/spec@1.0.0-rc.10':
     dependencies:
-      '@vltpkg/error-cause': 1.0.0-rc.9
-      '@vltpkg/semver': 1.0.0-rc.9
+      '@vltpkg/error-cause': 1.0.0-rc.10
+      '@vltpkg/semver': 1.0.0-rc.10
 
   '@vltpkg/types@0.0.0-30':
     dependencies:
@@ -6402,12 +6361,12 @@ snapshots:
       '@vltpkg/semver': 0.0.0-30
       '@vltpkg/spec': 0.0.0-30
 
-  '@vltpkg/types@1.0.0-rc.9':
+  '@vltpkg/types@1.0.0-rc.10':
     dependencies:
-      '@vltpkg/dep-id': 1.0.0-rc.9
-      '@vltpkg/error-cause': 1.0.0-rc.9
-      '@vltpkg/semver': 1.0.0-rc.9
-      '@vltpkg/spec': 1.0.0-rc.9
+      '@vltpkg/dep-id': 1.0.0-rc.10
+      '@vltpkg/error-cause': 1.0.0-rc.10
+      '@vltpkg/semver': 1.0.0-rc.10
+      '@vltpkg/spec': 1.0.0-rc.10
 
   '@volar/language-core@2.4.23':
     dependencies:
@@ -6559,13 +6518,15 @@ snapshots:
       '@whatwg-node/promise-helpers': 1.3.2
       tslib: 2.8.1
 
-  '@wollybeard/kit@0.103.1(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)':
+  '@wollybeard/kit@0.104.0(@effect/platform@0.92.1(effect@3.18.4))(effect@3.18.4)(zod@3.24.3)':
     dependencies:
       '@effect/platform': 0.92.1(effect@3.18.4)
       '@microsoft/tsdoc': 0.15.1
+      '@standard-schema/spec': 1.0.0
       '@types/node': 24.9.1
       '@types/object-inspect': 1.13.0
-      '@vltpkg/semver': 1.0.0-rc.9
+      '@vltpkg/semver': 1.0.0-rc.10
+      alge: 0.8.1
       ansis: 4.2.0
       arkregex: 0.0.3
       consola: 3.4.2
@@ -6584,6 +6545,8 @@ snapshots:
       ts-morph: 27.0.2
       type-fest: 5.1.0
       unified: 11.0.5
+    optionalDependencies:
+      zod: 3.24.3
     transitivePeerDependencies:
       - supports-color
 
@@ -7856,11 +7819,7 @@ snapshots:
 
   lodash-es@4.17.21: {}
 
-  lodash.camelcase@4.3.0: {}
-
   lodash.ismatch@4.4.0: {}
-
-  lodash.snakecase@4.1.1: {}
 
   lodash@4.17.21: {}
 
@@ -8566,8 +8525,6 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
-  readline-sync@1.4.10: {}
-
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
@@ -8875,10 +8832,6 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
-  string-length@6.0.0:
-    dependencies:
-      strip-ansi: 7.1.2
-
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -9060,8 +9013,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  type-fest@4.41.0: {}
 
   type-fest@5.1.0:
     dependencies:

--- a/scripts/generate-examples-derivatives/generate.ts
+++ b/scripts/generate-examples-derivatives/generate.ts
@@ -1,12 +1,14 @@
-import { Command } from '@molt/command'
-import { z } from 'zod'
+import { Command } from '@wollybeard/kit/oak'
+import { EffectSchema } from '@wollybeard/kit/oak/extensions'
+import { Schema } from 'effect'
 import { generateDocs } from './generate-docs.js'
 import { generateOutputs } from './generate-outputs.js'
 import { readExamples } from './helpers.js'
 
-const args = Command.create()
-  .parameter(`outputs`, z.boolean().optional())
-  .parameter(`name`, z.string().optional())
+const args = await Command.create()
+  .use(EffectSchema)
+  .parameter(`outputs`, Schema.UndefinedOr(Schema.Boolean))
+  .parameter(`name`, Schema.UndefinedOr(Schema.String))
   .parse()
 
 if (args.outputs) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,104 +2,105 @@
 
 import { type ConfigInit, ImportFormat, OutputCase } from '#src/generator/config/configInit.js'
 import { toAbsolutePath } from '#src/lib/fsp.js'
-import { Command } from '@molt/command'
 import { Err, Url } from '@wollybeard/kit'
+import { Command } from '@wollybeard/kit/oak'
+import { EffectSchema } from '@wollybeard/kit/oak/extensions'
+import { Schema as S } from 'effect'
 import * as Path from 'node:path'
-import { z } from 'zod'
 import { Generator } from '../generator/_.js'
 
 const args = Command.create()
+  .use(EffectSchema)
   .description(`Generate a type safe GraphQL client.`)
   .parameter(
     `name`,
-    z
-      .string()
-      .min(1)
-      .optional()
-      .describe(
-        `The name of your client. If you are not generating multiple clients you probably do not need this. Otherwise you need to differentiate the clients so that their global type registrations do not conflict. It is possible to leave one client unnamed which will become the default client at the type level (e.g. in configuration etc.)`,
-      ),
+    S.UndefinedOr(S.String.pipe(S.minLength(1))).pipe(
+      S.annotations({
+        description:
+          `The name of your client. If you are not generating multiple clients you probably do not need this. Otherwise you need to differentiate the clients so that their global type registrations do not conflict. It is possible to leave one client unnamed which will become the default client at the type level (e.g. in configuration etc.)`,
+      }),
+    ),
   )
   .parameter(
     `schema`,
-    z
-      .string()
-      .min(1)
-      .optional()
-      .describe(
-        `Path to where your GraphQL schema is. If a URL is given it will be introspected. Otherwise assumed to be a path to your GraphQL SDL file. If a directory path is given, then will look for a "schema.graphql" within that directory. Otherwise will attempt to load the exact file path given. If omitted, then your project must have a configuration file which supplies the schema source.`,
-      ),
+    S.UndefinedOr(S.String.pipe(S.minLength(1))).pipe(
+      S.annotations({
+        description:
+          `Path to where your GraphQL schema is. If a URL is given it will be introspected. Otherwise assumed to be a path to your GraphQL SDL file. If a directory path is given, then will look for a "schema.graphql" within that directory. Otherwise will attempt to load the exact file path given. If omitted, then your project must have a configuration file which supplies the schema source.`,
+      }),
+    ),
   )
   .parameter(
     `project`,
-    z
-      .string()
-      .optional()
-      .describe(
-        `Path to your configuration file. By default will look for "graffle.config.{ts,js,mjs,mts}" in the current working directory. If a directory path is given, then will look for "graffle.config.{ts,js,mjs,mts}" in that directory.`,
-      ),
+    S.UndefinedOr(S.String).pipe(
+      S.annotations({
+        description:
+          `Path to your configuration file. By default will look for "graffle.config.{ts,js,mjs,mts}" in the current working directory. If a directory path is given, then will look for "graffle.config.{ts,js,mjs,mts}" in that directory.`,
+      }),
+    ),
   )
   .parameter(
     `defaultSchemaUrl`,
-    z
-      .union([
-        z
-          .boolean()
-          .describe(
-            `If a GraphQL endpoint is given for "--schema", should it be set as the default URL in the generated client. If true then the client will default to using this URL when sending requests.`,
-          ),
-        z
-          .string()
-          .min(1)
-          .describe(
-            `A GraphQL endpoint to be used as the default URL in the generated client for requests.`,
-          ),
-      ])
-      .optional(),
+    S.UndefinedOr(
+      S.Union(
+        S.Boolean.pipe(
+          S.annotations({
+            description:
+              `If a GraphQL endpoint is given for "--schema", should it be set as the default URL in the generated client. If true then the client will default to using this URL when sending requests.`,
+          }),
+        ),
+        S.String.pipe(
+          S.minLength(1),
+          S.annotations({
+            description: `A GraphQL endpoint to be used as the default URL in the generated client for requests.`,
+          }),
+        ),
+      ),
+    ),
   )
   .parameter(
     `output`,
-    z
-      .string()
-      .min(1)
-      .optional()
-      .describe(
-        `Directory path for where to output the generated TypeScript files. By default will be './graffle' in the project root.`,
-      ),
+    S.UndefinedOr(S.String.pipe(S.minLength(1))).pipe(
+      S.annotations({
+        description:
+          `Directory path for where to output the generated TypeScript files. By default will be './graffle' in the project root.`,
+      }),
+    ),
   )
   .parameter(
     `outputCase`,
-    z
-      .nativeEnum(OutputCase)
-      .optional()
-      .describe(`The case format to use for the generated file names.`),
+    S.UndefinedOr(OutputCase).pipe(
+      S.annotations({
+        description: `The case format to use for the generated file names.`,
+      }),
+    ),
   )
   .parameter(
     `format`,
-    z
-      .boolean()
-      .describe(
-        `Try to format the generated files. At attempt to use dprint will be made. You need to have these dependencies installed in your project: @dprint/formatter, @dprint/typescript.`,
-      )
-      .optional(),
+    S.UndefinedOr(S.Boolean).pipe(
+      S.annotations({
+        description:
+          `Try to format the generated files. At attempt to use dprint will be made. You need to have these dependencies installed in your project: @dprint/formatter, @dprint/typescript.`,
+      }),
+    ),
   )
   .parameter(
     `importFormat`,
-    z
-      .nativeEnum(ImportFormat)
-      .optional()
-      .describe(
-        `How should import identifiers be generated? For example "tsExtension" would yield modules that import like "import ... from './foo.ts'".`,
-      ),
+    S.UndefinedOr(ImportFormat).pipe(
+      S.annotations({
+        description:
+          `How should import identifiers be generated? For example "tsExtension" would yield modules that import like "import ... from './foo.ts'".`,
+      }),
+    ),
   )
   .parameter(
     `outputSdl`,
-    z
-      .boolean()
-      .optional()
-      .describe(
-        `Output the GraphQL schema SDL to a file. When explicitly set, always applies regardless of schema source.`,
-      ),
+    S.UndefinedOr(S.Boolean).pipe(
+      S.annotations({
+        description:
+          `Output the GraphQL schema SDL to a file. When explicitly set, always applies regardless of schema source.`,
+      }),
+    ),
   )
   .settings({
     parameters: {

--- a/src/generator/config/configInit.ts
+++ b/src/generator/config/configInit.ts
@@ -1,5 +1,6 @@
 import type { Fs } from '#src/lib/fsp.js'
 import type { GraphqlKit } from '#src/lib/graphql-kit/_.js'
+import { Schema } from 'effect'
 import type { IntrospectionOptions } from 'graphql'
 import type { Extension } from '../extension/types.js'
 
@@ -22,20 +23,24 @@ export interface InputLint {
   missingGraphqlSP?: boolean
 }
 
-export const OutputCase = {
-  pascal: `pascal`,
-  camel: `camel`,
-  kebab: `kebab`,
-  snake: `snake`,
-} as const
-export type InputOutputCase = keyof typeof OutputCase
+export const OutputCase = Schema.Enums(
+  {
+    pascal: `pascal`,
+    camel: `camel`,
+    kebab: `kebab`,
+    snake: `snake`,
+  } as const,
+)
+export type InputOutputCase = typeof OutputCase.Type
 
-export const ImportFormat = {
-  jsExtension: `jsExtension`,
-  tsExtension: `tsExtension`,
-  noExtension: `noExtension`,
-} as const
-export type InputImportFormat = keyof typeof ImportFormat
+export const ImportFormat = Schema.Enums(
+  {
+    jsExtension: `jsExtension`,
+    tsExtension: `tsExtension`,
+    noExtension: `noExtension`,
+  } as const,
+)
+export type InputImportFormat = typeof ImportFormat.Type
 
 export interface ConfigInitSchemaSdl {
   type: `sdl`


### PR DESCRIPTION
## Summary

- Replace `@molt/command` (Zod-based) with Oak from `@wollybeard/kit` using Effect Schema for CLI parameter definitions
- Convert all 9 CLI parameters to Effect Schema
- Update `scripts/generate-examples-derivatives/generate.ts` to use Oak
- Remove `@molt/command` from dependencies

This removes the Zod dependency from the CLI layer in favor of Effect Schema.

## Test plan

- [x] `pnpm check:types` passes
- [x] `pnpm graffle --help` displays correct parameter information
- [x] CLI accepts and parses parameters correctly