### PR TITLE
fix(graphql-request): resolve relative endpoint URLs against current origin

### DIFF
--- a/src/legacy/helpers/runRequest.ts
+++ b/src/legacy/helpers/runRequest.ts
@@ -173,6 +173,13 @@ const parseResultFromText = (text: string, contentType: string | null, jsonSeria
   }
 }
 
+// Resolve relative endpoints (e.g. `/graphql`) against the current origin when running in a browser.
+const toRequestUrl = (url: string): URL => {
+  const location = (globalThis as { location?: { href?: string } }).location
+  const base = location && typeof location.href === `string` ? location.href : undefined
+  return base ? new URL(url, base) : new URL(url)
+}
+
 const createFetcher = (method: 'GET' | 'POST') => async (params: Input) => {
   const headers = new Headers(params.headers)
   let searchParams: URLSearchParams | null = null
@@ -194,7 +201,7 @@ const createFetcher = (method: 'GET' | 'POST') => async (params: Input) => {
 
   const init: RequestInit = { method, headers, body, ...params.fetchOptions }
 
-  let url = new URL(params.url)
+  let url = toRequestUrl(params.url)
   let initResolved = init
 
   if (params.middleware) {
@@ -207,7 +214,7 @@ const createFetcher = (method: 'GET' | 'POST') => async (params: Input) => {
       }),
     )
     const { url: urlNew, ...initNew } = result
-    url = new URL(urlNew)
+    url = toRequestUrl(urlNew)
     initResolved = initNew
   }
 

--- a/tests/legacy/endpoint.test.ts
+++ b/tests/legacy/endpoint.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test } from 'vitest'
 import { GraphQLClient } from '../../src/entrypoints/main.js'
 import { setupMockServer } from './__helpers.js'
 
@@ -21,5 +21,25 @@ describe(`using class`, () => {
     await client.request(`{ test }`)
     expect(mock_0.requests.length).toEqual(1)
     expect(mock_1.requests.length).toEqual(2)
+  })
+})
+
+describe(`relative endpoint`, () => {
+  afterEach(() => {
+    delete (globalThis as { location?: unknown }).location
+  })
+
+  test(`is resolved against the current origin in a browser-like environment`, async () => {
+    ;(globalThis as { location?: unknown }).location = { href: `https://example.org/app/` }
+    let requestedUrl: string | undefined
+    const customFetch = (input: RequestInfo | URL): Promise<Response> => {
+      requestedUrl = String(input)
+      return Promise.resolve(new Response(JSON.stringify({ data: { ok: true } }), {
+        headers: { 'content-type': `application/json` },
+      }))
+    }
+    const client = new GraphQLClient(`/graphql`, { fetch: customFetch })
+    await client.request(`{ ok }`)
+    expect(requestedUrl).toEqual(`https://example.org/graphql`)
   })
 })


### PR DESCRIPTION
graphql-request 7.4.0 parses the endpoint with `new URL(params.url)` in `runRequest`, which throws for relative endpoints like `/graphql` that worked previously in browser contexts. This resolves the endpoint (and any middleware-returned URL) against `globalThis.location` when available so relative paths keep working, while leaving non-browser behavior unchanged. Closes #1493.