### PR TITLE
fix: avoid TS2742 in generated client under pnpm isolated node_modules

### DIFF
--- a/examples/$/graffle/modules/client.ts
+++ b/examples/$/graffle/modules/client.ts
@@ -1,3 +1,4 @@
+import type { Create } from 'graffle/client'
 import { DocumentBuilder } from 'graffle/extensions/document-builder'
 import { TransportHttp } from 'graffle/extensions/transport-http'
 import * as $$Utilities from 'graffle/utilities-for-generated'
@@ -50,4 +51,4 @@ const context = $$Utilities.pipe(
  * const result = await client.query.pokemon({ name: true })
  * ```
  */
-export const create = $$Utilities.createConstructorWithContext(context)
+export const create: Create<typeof context> = $$Utilities.createConstructorWithContext(context)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,20 @@
     "./extensions/schema-errors": "./build/exports/extensions/schema-errors/runtime.js",
     "./extensions/transport-http": "./build/exports/extensions/transport-http/runtime.js",
     "./extensions/transport-memory": "./build/exports/extensions/transport-memory/runtime.js",
-    "./extensions/upload": "./build/exports/extensions/upload/runtime.js"
+    "./extensions/upload": "./build/exports/extensions/upload/runtime.js",
+    "./build/client/client.js": "./build/client/client.js",
+    "./build/client/handle.js": "./build/client/handle.js",
+    "./build/context/fragments/configuration/check/check.js": "./build/context/fragments/configuration/check/check.js",
+    "./build/context/fragments/configuration/fragment.js": "./build/context/fragments/configuration/fragment.js",
+    "./build/context/fragments/configuration/output/configuration.js": "./build/context/fragments/configuration/output/configuration.js",
+    "./build/context/fragments/configuration/schema/configuration.js": "./build/context/fragments/configuration/schema/configuration.js",
+    "./build/context/fragments/extensions/fragment.js": "./build/context/fragments/extensions/fragment.js",
+    "./build/context/fragments/properties/fragment.js": "./build/context/fragments/properties/fragment.js",
+    "./build/context/fragments/requestInterceptors/helpers.js": "./build/context/fragments/requestInterceptors/helpers.js",
+    "./build/context/fragments/transports/dataType/data.js": "./build/context/fragments/transports/dataType/data.js",
+    "./build/context/fragments/transports/__.js": "./build/context/fragments/transports/__.js",
+    "./build/client/methods/gql/DocumentSender.js": "./build/client/methods/gql/DocumentSender.js",
+    "./build/lib/graphql-kit/document/__.js": "./build/lib/graphql-kit/document/__.js"
   },
   "files": [
     "build",

--- a/src/exports/client.ts
+++ b/src/exports/client.ts
@@ -1,4 +1,4 @@
-export { type Client, create } from '#src/client/client.js'
+export { type Client, type Create, create } from '#src/client/client.js'
 export { Var } from '#src/lib/graphql-kit/document/__.js'
 export { create as createSelect, select } from '#src/select/select.js'
 // TODO remove this hacky export

--- a/src/extensions/SchemaErrors/__tests__/fixture/graffle/modules/client.ts
+++ b/src/extensions/SchemaErrors/__tests__/fixture/graffle/modules/client.ts
@@ -1,3 +1,4 @@
+import type { Create } from '#graffle/client'
 import { DocumentBuilder } from '#graffle/extensions/document-builder'
 import { TransportHttp } from '#graffle/extensions/transport-http'
 import * as $$Utilities from '#graffle/utilities-for-generated'
@@ -49,4 +50,4 @@ const context = $$Utilities.pipe(
  * const result = await client.query.pokemon({ name: true })
  * ```
  */
-export const create = $$Utilities.createConstructorWithContext(context)
+export const create: Create<typeof context> = $$Utilities.createConstructorWithContext(context)

--- a/src/generator/generators/Client.ts
+++ b/src/generator/generators/Client.ts
@@ -31,6 +31,13 @@ export const ModuleGeneratorClient = createModuleGenerator(
         from: config.paths.imports.grafflePackage.extensionDocumentBuilder,
       }),
     )
+    code(
+      Syn.TS.importNamed({
+        names: 'Create',
+        from: config.paths.imports.grafflePackage.client,
+        type: true,
+      }),
+    )
 
     code`
       const context = ${$.$$Utilities}.pipe(
@@ -77,7 +84,7 @@ export const ModuleGeneratorClient = createModuleGenerator(
        * const result = await client.query.pokemon({ name: true })
        * \`\`\`
        */
-      export const create = ${$.$$Utilities}.createConstructorWithContext(context)
+      export const create: Create<typeof context> = ${$.$$Utilities}.createConstructorWithContext(context)
     `
   },
 )


### PR DESCRIPTION
The generated `create` function had an inferred return type that transitively referenced `@wollybeard/kit` internals through subpath barrels TypeScript could not portably name when emitting declarations under pnpm's isolated node_modules layout, producing TS2742 errors in consumer projects.

- Export the `Create` type from the main client entry so the generator can refer to it by a portable name.
- Make the generator emit a type-only import of `Create` and annotate the generated `create` with `Create<typeof context>`, giving the emitted declaration a nameable return type.
- Expose the `build/*` subpaths referenced by the generated declaration via `package.json` `exports` so consumers can actually resolve them.

Refs #1484